### PR TITLE
Fix maple sap portion size, weight and debug spawning

### DIFF
--- a/data/json/items/comestibles/drink_other.json
+++ b/data/json/items/comestibles/drink_other.json
@@ -34,8 +34,9 @@
     "price": 50,
     "weight": 250,
     "volume": 1,
+	"charges": 1,
     "comestible_type": "DRINK",
-    "container": "bucket",
+    "container": "metal_tank",
     "quench": 45,
     "//": "need 40 parts maple sap to make 1 part maple syrup",
     "proportional": { "calories": 0.025 },
@@ -193,6 +194,7 @@
     "charges": 16,
     "phase": "liquid",
     "fun": -25,
+    "flags": "NUTRIENT_OVERRIDE",
     "freezing_point": 14
   },
   {


### PR DESCRIPTION
#### Summary
Changes maple sap portions and density to be same as water. Also changes the container from bucket to 60 l metal tank.

```SUMMARY: Bugfixes "Fixes maple sap portions and density and default container"```

#### Purpose of change
Currently 0.25 l of maple sap is actually four portions. This causes 0.25 l of sap to weight 4 kg and allows you to drink from it four times.

It was also impossible to spawn maple sap from debug menu. It would spawn in a bucket and buckets can not hold liquids in inventory. The result was empty bucket and sap on ground.

#### Describe the solution
The problem was that the copy-from copied the portions from maple syrup. Simply overwrite it with "charges": 1. Now 0.25 l of maple syrup weights 0.25 kg and is one portion.

The default container was changed to 60 l metal container.

#### Describe alternatives you've considered
I am not sure if the default container is used anywhere else than when spawning items with debug menu. If it is used somewhere else then the default container may need to be rethinked.

