### PR TITLE
Temp improvements

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1046,9 +1046,9 @@ static void butchery_drops_harvest( item *corpse_item, const mtype &mt, player &
                 item obj( drop, calendar::turn, roll );
                 if( obj.has_temperature() ) {
                     obj.set_item_temperature( 0.00001 * corpse_item->temperature );
-                }
-                if( obj.goes_bad() ) {
-                    obj.set_rot( corpse_item->get_rot() );
+                    if( obj.goes_bad() ) {
+                        obj.set_rot( corpse_item->get_rot() );
+                    }
                 }
                 for( const std::string &flg : entry.flags ) {
                     obj.set_flag( flg );
@@ -1066,9 +1066,9 @@ static void butchery_drops_harvest( item *corpse_item, const mtype &mt, player &
                 item obj( drop, calendar::turn, roll );
                 if( obj.has_temperature() ) {
                     obj.set_item_temperature( 0.00001 * corpse_item->temperature );
-                }
-                if( obj.goes_bad() ) {
-                    obj.set_rot( corpse_item->get_rot() );
+                    if( obj.goes_bad() ) {
+                        obj.set_rot( corpse_item->get_rot() );
+                    }
                 }
                 for( const std::string &flg : entry.flags ) {
                     obj.set_flag( flg );
@@ -1085,9 +1085,9 @@ static void butchery_drops_harvest( item *corpse_item, const mtype &mt, player &
                 obj.set_mtype( &mt );
                 if( obj.has_temperature() ) {
                     obj.set_item_temperature( 0.00001 * corpse_item->temperature );
-                }
-                if( obj.goes_bad() ) {
-                    obj.set_rot( corpse_item->get_rot() );
+                    if( obj.goes_bad() ) {
+                        obj.set_rot( corpse_item->get_rot() );
+                    }
                 }
                 for( const std::string &flg : entry.flags ) {
                     obj.set_flag( flg );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1194,7 +1194,6 @@ void player::complete_craft( item &craft, const tripoint &loc )
                 //
                 // Temperature is not functional for non-foods
                 food_contained.set_item_temperature( 293.15 );
-                food_contained.reset_temp_check();
             }
         }
 
@@ -1224,7 +1223,6 @@ void player::complete_craft( item &craft, const tripoint &loc )
                     bp.heat_up();
                 } else {
                     bp.set_item_temperature( 293.15 );
-                    bp.reset_temp_check();
                 }
             }
             bp.set_owner( get_faction()->id );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1179,11 +1179,10 @@ void player::complete_craft( item &craft, const tripoint &loc )
             newit_counter++;
         }
 
-        if( food_contained.goes_bad() ) {
-            food_contained.set_relative_rot( relative_rot );
-        }
-
         if( food_contained.has_temperature() ) {
+            if( food_contained.goes_bad() ) {
+                food_contained.set_relative_rot( relative_rot );
+            }
             if( should_heat ) {
                 food_contained.heat_up();
             } else {
@@ -1217,10 +1216,10 @@ void player::complete_craft( item &craft, const tripoint &loc )
     if( making.has_byproducts() ) {
         std::vector<item> bps = making.create_byproducts( batch_size );
         for( auto &bp : bps ) {
-            if( bp.goes_bad() ) {
-                bp.set_relative_rot( relative_rot );
-            }
             if( bp.has_temperature() ) {
+                if( bp.goes_bad() ) {
+                    bp.set_relative_rot( relative_rot );
+                }
                 if( should_heat ) {
                     bp.heat_up();
                 } else {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9399,6 +9399,7 @@ bool item::process_blackpowder_fouling( player *carrier )
 bool item::process( player *carrier, const tripoint &pos, bool activate, float insulation,
                     temperature_flag flag )
 {
+    const bool preserves = type->container && type->container->preserves;
     std::vector<item *> removed_items;
     visit_items( [&]( item * it ) {
         if( preserves ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9401,7 +9401,7 @@ bool item::process( player *carrier, const tripoint &pos, bool activate, float i
 {
     std::vector<item *> removed_items;
     visit_items( [&]( item * it ) {
-		        if( preserves ) {
+        if( preserves ) {
             // Simulate that the item has already "rotten" up to last_rot_check, but as item::rot
             // is not changed, the item is still fresh.
             it->last_rot_check = calendar::turn;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5196,9 +5196,6 @@ int get_hourly_rotpoints_at_temp( const int temp )
 
 void item::calc_rot( time_point time, int temp )
 {
-    if( !goes_bad() ) {
-        return;
-    }
     // Avoid needlessly calculating already rotten things.  Corpses should
     // always rot away and food rots away at twice the shelf life.  If the food
     // is in a sealed container they won't rot away, this avoids needlessly

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8634,13 +8634,8 @@ void item::process_temperature_rot( float insulation, const tripoint &pos,
     }
 
     time_point time;
-    const bool preserved = type->container && type->container->preserves;
     item_internal::scoped_goes_bad_cache _( this );
-    const bool process_rot = goes_bad() && !preserved;
-
-    if( preserved && goes_bad() ) {
-        last_rot_check = now;
-    }
+    const bool process_rot = goes_bad();
 
     if( process_rot ) {
         time = std::min( last_rot_check, last_temp_check );
@@ -9406,6 +9401,11 @@ bool item::process( player *carrier, const tripoint &pos, bool activate, float i
 {
     std::vector<item *> removed_items;
     visit_items( [&]( item * it ) {
+		        if( preserves ) {
+            // Simulate that the item has already "rotten" up to last_rot_check, but as item::rot
+            // is not changed, the item is still fresh.
+            it->last_rot_check = calendar::turn;
+        }
         if( it->process_internal( carrier, pos, activate, type->insulation_factor * insulation, flag ) ) {
             removed_items.push_back( it );
         }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1509,12 +1509,12 @@ void item::basic_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
                                           to_turns<int>( food->get_shelf_life() ) ) );
                 info.push_back( iteminfo( "BASE", _( "last rot: " ),
                                           "", iteminfo::lower_is_better,
-                                          to_turn<int>( food->last_rot_check ) ) );
+                                          to_turn<int>( food->last_rot_check ) ) );  
+            }
+            if( food && food->has_temperature() ) {
                 info.push_back( iteminfo( "BASE", _( "last temp: " ),
                                           "", iteminfo::lower_is_better,
                                           to_turn<int>( food->last_temp_check ) ) );
-            }
-            if( food && food->has_temperature() ) {
                 info.push_back( iteminfo( "BASE", _( "Temp: " ), "", iteminfo::lower_is_better,
                                           food->temperature ) );
                 info.push_back( iteminfo( "BASE", _( "Spec ener: " ), "",

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8634,15 +8634,16 @@ void item::process_temperature_rot( float insulation, const tripoint &pos,
     }
 
     time_point time;
-	const bool preserved = type->container && type->container->preserves;
-	item_internal::scoped_goes_bad_cache _( this );
-	const bool process_rot = goes_bad() && !preserved;
-    
+    const bool preserved = type->container && type->container->preserves;
+    item_internal::scoped_goes_bad_cache _( this );
+    const bool process_rot = goes_bad() && !preserved;
+
+    if( preserved && goes_bad() ) {
+        last_rot_check = now;
+    }
+
     if( process_rot ) {
         time = std::min( last_rot_check, last_temp_check );
-		if ( preserved ){
-			last_rot_check = now;
-		}
     } else {
         time = last_temp_check;
     }
@@ -8713,8 +8714,8 @@ void item::process_temperature_rot( float insulation, const tripoint &pos,
                 calc_temp( env_temperature, insulation, time );
             }
 
-            // Calculate item rot from item temperature
-            if( time - last_rot_check > smallest_interval ) {
+            // Calculate item rot
+            if( process_rot && time - last_rot_check > smallest_interval ) {
                 calc_rot( time, env_temperature );
 
                 if( has_rotten_away() || ( is_corpse() && rot > 10_days ) ) {
@@ -8729,9 +8730,9 @@ void item::process_temperature_rot( float insulation, const tripoint &pos,
     // and items that are held near the player
     if( now - time > smallest_interval ) {
         calc_temp( temp, insulation, now );
-		if( process_rot ){
-			calc_rot( now, temp );
-		}
+        if( process_rot ) {
+            calc_rot( now, temp );
+        }
         return;
     }
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8540,7 +8540,6 @@ int iuse::multicooker( player *p, item *it, bool t, const tripoint &pos )
             } else {
                 meal.set_item_temperature( temp_to_kelvin( std::max( temperatures::cold,
                                            g->weather.get_temperature( pos ) ) ) );
-                meal.reset_temp_check();
             }
 
             it->active = false;


### PR DESCRIPTION
#### Summary

```SUMMARY: Infrastructure "Minor rot code improvements"```

#### Purpose of change
Temperature and rot code has some unnecessary, unintuitive or odd parts.

#### Describe the solution

All items that rot also have temperature. Moved `goes_bad()` checks to happen only if `has_temperature()` is true.

`set_item_temperature()` resets `last_temp_check`. Removed unnecessary `reset_temp_check()`.

Debug menu now shows `last_temp_check` for items that have temperature but do not have rot (for example water).

`goes_bad()` in `item::calc_rot` is unnecessary because that is already checked in `item::process_temperature_rot`.

#### Describe alternatives you've considered
<!--
A clear and concise description of any alternative solutions or features you've considered.
-->

#### Testing
Normal items seem to rot normally.
Preserved items do not rot.

#### Additional context
Should not change anything visible to the player.
