### PR TITLE
Tests for items in preserving container and in freezer

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5222,7 +5222,7 @@ void item::calc_rot( time_point time, int temp )
     }
 
     if( item_tags.count( "COLD" ) ) {
-        temp = temperatures::fridge;
+        temp = std::min( temperatures::fridge, temp );
     }
 
     // simulation of different age of food at the start of the game and good/bad storage

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -27,24 +27,47 @@ static void set_map_temperature( int new_temperature )
 
 TEST_CASE( "Rate of rotting" )
 {
-    SECTION( "65 F" ) {
+    SECTION( "Passage of time" ) {
         // Item rot is a time duration.
         // At 65 F (18,3 C) item rots at rate of 1h/1h
         // So the level of rot should be about same as the item age
+        // In preserving containers and in freezer the item should not rot at all
 
-        item test_item( "meat_cooked" );
+        item normal_item( "meat_cooked" );
+
+        item freeze_item( "offal_canned" );
+
+        item sealed_item( "offal_canned" );
+        sealed_item = sealed_item.in_its_container();
 
         set_map_temperature( 65 ); // 18,3 C
 
-        test_item.process_temperature_rot( 1, tripoint_zero, nullptr );
+        normal_item.process( nullptr, tripoint_zero, false, 1, temperature_flag::TEMP_NORMAL );
+        sealed_item.process( nullptr, tripoint_zero, false, 1, temperature_flag::TEMP_NORMAL );
+        freeze_item.process( nullptr, tripoint_zero, false, 1, temperature_flag::TEMP_FREEZER );
 
         // Item should exist with no rot when it is brand new
-        CHECK( to_turns<int>( test_item.get_rot() ) == 0 );
+        CHECK( to_turns<int>( normal_item.get_rot() ) == 0 );
+        CHECK( to_turns<int>( sealed_item.get_rot() ) == 0 );
+        CHECK( to_turns<int>( freeze_item.get_rot() ) == 0 );
 
         calendar::turn = to_turn<int>( calendar::turn + 20_minutes );
-        test_item.process_temperature_rot( 1, tripoint_zero, nullptr );
+        normal_item.process( nullptr, tripoint_zero, false, 1, temperature_flag::TEMP_NORMAL );
+        sealed_item.process( nullptr, tripoint_zero, false, 1, temperature_flag::TEMP_NORMAL );
+        freeze_item.process( nullptr, tripoint_zero, false, 1, temperature_flag::TEMP_FREEZER );
 
-        // After 20 minutes the item should have 20 minutes of rot
-        CHECK( is_nearly( to_turns<int>( test_item.get_rot() ), to_turns<int>( 20_minutes ) ) );
+        // After 20 minutes the normal item should have 20 minutes of rot
+        CHECK( is_nearly( to_turns<int>( normal_item.get_rot() ), to_turns<int>( 20_minutes ) ) );
+        // Item in freezer and in preserving container should have no rot
+        CHECK( to_turns<int>( sealed_item.get_rot() ) == 0 );
+        CHECK( to_turns<int>( freeze_item.get_rot() ) == 0 );
+
+        // Move time 110 minutes
+        calendar::turn = to_turn<int>( calendar::turn + 110_minutes );
+        sealed_item.process( nullptr, tripoint_zero, false, 1, temperature_flag::TEMP_NORMAL );
+        freeze_item.process( nullptr, tripoint_zero, false, 1, temperature_flag::TEMP_FREEZER );
+        // In freezer and in preserving container still should be no rot
+        CHECK( to_turns<int>( sealed_item.get_rot() ) == 0 );
+        CHECK( to_turns<int>( freeze_item.get_rot() ) == 0 );
     }
 }

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -32,6 +32,7 @@ TEST_CASE( "Rate of rotting" )
         // At 65 F (18,3 C) item rots at rate of 1h/1h
         // So the level of rot should be about same as the item age
         // In preserving containers and in freezer the item should not rot at all
+        // Item in freezer should not be frozen.
 
         item normal_item( "meat_cooked" );
 
@@ -44,7 +45,7 @@ TEST_CASE( "Rate of rotting" )
 
         normal_item.process( nullptr, tripoint_zero, false, 1, temperature_flag::TEMP_NORMAL );
         sealed_item.process( nullptr, tripoint_zero, false, 1, temperature_flag::TEMP_NORMAL );
-        freeze_item.process( nullptr, tripoint_zero, false, 1, temperature_flag::TEMP_FREEZER );
+        freeze_item.process( nullptr, tripoint_zero, false, 1, temperature_flag::TEMP_NORMAL );
 
         // Item should exist with no rot when it is brand new
         CHECK( to_turns<int>( normal_item.get_rot() ) == 0 );
@@ -69,5 +70,8 @@ TEST_CASE( "Rate of rotting" )
         // In freezer and in preserving container still should be no rot
         CHECK( to_turns<int>( sealed_item.get_rot() ) == 0 );
         CHECK( to_turns<int>( freeze_item.get_rot() ) == 0 );
+
+        // The item in freezer should still not be frozen
+        CHECK( !freeze_item.item_tags.count( "FROZEN" ) );
     }
 }


### PR DESCRIPTION
#### Summary

```SUMMARY: Infrastructure "Tests for items in preserving container and in freezer"```

#### Purpose of change

These two were not tested requiring them to be manually tested for any rot related code changes.
Now they are tested automatically.

#### Describe the solution
In the rot test crete two more items.
Put one of the items in container that preserves it (canned).
Process the other item as being in freezer.
These two items are checked after 20 minutes (with the normal item).
These  two are tested again 110 minutes later (normal item is not due to weather potentially messing things up).

Also changed the test to use item::process instead of calling item::process_temperature_rot directly. item::process_temperature_rot does not know that the item is in preserving container and this is the natural order anyways.

#### Describe alternatives you've considered
Could be made into separate test cases.

#### Testing
It is a test.
 The test passes.

#### Additional context

