### PR TITLE
bearings

### DIFF
--- a/data/json/recipes/recipe_ammo.json
+++ b/data/json/recipes/recipe_ammo.json
@@ -71,7 +71,7 @@
     "book_learn": [ [ "textbook_fabrication", 1 ] ],
     "using": [ [ "forging_standard", 5 ] ],
     "tools": [ [ [ "press", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "components": [ [ [ "weights", 10, "LIST" ], [ "steel_standard", 6, "LIST" ] ] ]
+    "components": [ [ [ "weights", 34, "LIST" ], [ "steel_tiny", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/recipe_ammo.json
+++ b/data/json/recipes/recipe_ammo.json
@@ -69,9 +69,9 @@
     "time": "45 m",
     "autolearn": true,
     "book_learn": [ [ "textbook_fabrication", 1 ] ],
-    "using": [ [ "forging_standard", 5 ], [ "steel_standard", 6 ] ],
+    "using": [ [ "forging_standard", 5 ] ],
     "tools": [ [ [ "press", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "components": [ [ [ "weights", 10, "LIST" ] ] ]
+    "components": [ [ [ "weights", 10, "LIST" ], [ "steel_standard", 6, "LIST" ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION

#### Summary

```SUMMARY: Bugfixes "Fix bearing requiring both "weight" and "steel""```

#### Purpose of change

Crafting bearings requires both weight (lead/gold/silver...) and steel. So the bearings were always made of steel and some other random metal.

You should be able to make the bearings from one metal only.

#### Describe the solution

Move "steel_standard" from using to component.

#### Describe alternatives you've considered

#### Testing

Recipe works.

#### Additional context

Before:
![before](https://user-images.githubusercontent.com/22011552/79308876-06dc8980-7f02-11ea-8832-b03a7d286fe8.png)

After:
![after](https://user-images.githubusercontent.com/22011552/79308891-0a701080-7f02-11ea-8b66-4a46ddb0e5a6.png)


