### PR TITLE
Map item processing refactoring

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1598,7 +1598,7 @@ bool game::do_turn()
     autopilot_vehicles();
     m.vehmove();
     m.process_fields();
-    m.process_active_items();
+    m.process_items();
     m.creature_in_field( u );
 
     // Apply sounds from previous turn to monster and NPC AI.

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4308,7 +4308,7 @@ void map::update_lum( item_location &loc, bool add )
 }
 
 static bool process_map_items( item_stack &items, safe_reference<item> &item_ref,
-                          const tripoint &location, const float insulation, const temperature_flag flag )
+                               const tripoint &location, const float insulation, const temperature_flag flag )
 {
     if( item_ref->process( nullptr, location, false, insulation, flag ) ) {
         // Item is to be destroyed so erase it from the map stack

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4307,7 +4307,7 @@ void map::update_lum( item_location &loc, bool add )
     }
 }
 
-static bool process_item( item_stack &items, safe_reference<item> &item_ref,
+static bool process_map_items( item_stack &items, safe_reference<item> &item_ref,
                           const tripoint &location, const float insulation, const temperature_flag flag )
 {
     if( item_ref->process( nullptr, location, false, insulation, flag ) ) {
@@ -4320,13 +4320,6 @@ static bool process_item( item_stack &items, safe_reference<item> &item_ref,
     }
     // Item not destroyed
     return false;
-}
-
-static bool process_map_items( item_stack &items, safe_reference<item> &item_ref,
-                               const tripoint &location,
-                               const float insulation, const temperature_flag flag )
-{
-    return process_item( items, item_ref, location, insulation, flag );
 }
 
 static void process_vehicle_items( vehicle &cur_veh, int part )

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4324,7 +4324,7 @@ static bool process_item( item_stack &items, safe_reference<item> &item_ref,
 }
 
 static bool process_map_items( item_stack &items, safe_reference<item> &item_ref,
-                               const tripoint &location, const std::string &,
+                               const tripoint &location,
                                const float insulation, const temperature_flag flag )
 {
     return process_item( items, item_ref, location, false, insulation, flag );
@@ -4418,7 +4418,7 @@ static void process_vehicle_items( vehicle &cur_veh, int part )
 
 void map::process_active_items()
 {
-    process_items( true, std::string {} );
+    process_items( true );
 }
 
 std::vector<tripoint> map::check_submap_active_item_consistency()
@@ -4447,8 +4447,7 @@ std::vector<tripoint> map::check_submap_active_item_consistency()
     return result;
 }
 
-void map::process_items( const bool active,
-                         const std::string &signal )
+void map::process_items( const bool active )
 {
     const int minz = zlevels ? -OVERMAP_DEPTH : abs_sub.z;
     const int maxz = zlevels ? OVERMAP_HEIGHT : abs_sub.z;
@@ -4462,7 +4461,7 @@ void map::process_items( const bool active,
         for( const tripoint &pos : submaps_with_vehicles ) {
             submap *const current_submap = get_submap_at_grid( pos );
             // Vehicles first in case they get blown up and drop active items on the map.
-            process_items_in_vehicles( *current_submap, pos.z, signal );
+            process_items_in_vehicles( *current_submap );
         }
     }
     // Making a copy, in case the original variable gets modified during `process_items_in_submap`
@@ -4471,13 +4470,12 @@ void map::process_items( const bool active,
         const tripoint local_pos = abs_pos - abs_sub.xy();
         submap *const current_submap = get_submap_at_grid( local_pos );
         if( !active || !current_submap->active_items.empty() ) {
-            process_items_in_submap( *current_submap, local_pos, signal );
+            process_items_in_submap( *current_submap, local_pos );
         }
     }
 }
 
-void map::process_items_in_submap( submap &current_submap, const tripoint &gridp,
-                                   const std::string &signal )
+void map::process_items_in_submap( submap &current_submap, const tripoint &gridp )
 {
     // Get a COPY of the active item list for this submap.
     // If more are added as a side effect of processing, they are ignored this turn.
@@ -4497,12 +4495,11 @@ void map::process_items_in_submap( submap &current_submap, const tripoint &gridp
             flag = temperature_flag::TEMP_ROOT_CELLAR;
         }
         map_stack items = i_at( map_location );
-        process_map_items( items, active_item_ref.item_ref, map_location, signal, 1, flag );
+        process_map_items( items, active_item_ref.item_ref, map_location, 1, flag );
     }
 }
 
-void map::process_items_in_vehicles( submap &current_submap, const int gridz,
-                                     const std::string &signal )
+void map::process_items_in_vehicles( submap &current_submap )
 {
     // a copy, important if the vehicle list changes because a
     // vehicle got destroyed by a bomb (an active item!), this list
@@ -4519,12 +4516,11 @@ void map::process_items_in_vehicles( submap &current_submap, const int gridz,
             continue;
         }
 
-        process_items_in_vehicle( *cur_veh, current_submap, gridz, signal );
+        process_items_in_vehicle( *cur_veh, current_submap );
     }
 }
 
-void map::process_items_in_vehicle( vehicle &cur_veh, submap &current_submap, const int /*gridz*/,
-                                    const std::string &signal )
+void map::process_items_in_vehicle( vehicle &cur_veh, submap &current_submap )
 {
     const bool engine_heater_is_on = cur_veh.has_part( "E_HEATER", true ) && cur_veh.engine_on;
     for( const vpart_reference &vp : cur_veh.get_any_parts( VPFLAG_FLUIDTANK ) ) {
@@ -4574,7 +4570,7 @@ void map::process_items_in_vehicle( vehicle &cur_veh, submap &current_submap, co
                 flag = temperature_flag::TEMP_FREEZER;
             }
         }
-        if( !process_map_items( items, active_item_ref.item_ref, item_loc, signal, it_insulation, flag ) ) {
+        if( !process_map_items( items, active_item_ref.item_ref, item_loc, it_insulation, flag ) ) {
             // If the item was NOT destroyed, we can skip the remainder,
             // which handles fallout from the vehicle being damaged.
             continue;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4308,10 +4308,9 @@ void map::update_lum( item_location &loc, bool add )
 }
 
 static bool process_item( item_stack &items, safe_reference<item> &item_ref,
-                          const tripoint &location,
-                          const bool activate, const float insulation, const temperature_flag flag )
+                          const tripoint &location, const float insulation, const temperature_flag flag )
 {
-    if( item_ref->process( nullptr, location, activate, insulation, flag ) ) {
+    if( item_ref->process( nullptr, location, false, insulation, flag ) ) {
         // Item is to be destroyed so erase it from the map stack
         // unless it was already destroyed by processing.
         if( item_ref ) {
@@ -4327,7 +4326,7 @@ static bool process_map_items( item_stack &items, safe_reference<item> &item_ref
                                const tripoint &location,
                                const float insulation, const temperature_flag flag )
 {
-    return process_item( items, item_ref, location, false, insulation, flag );
+    return process_item( items, item_ref, location, insulation, flag );
 }
 
 static void process_vehicle_items( vehicle &cur_veh, int part )

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4418,7 +4418,7 @@ static void process_vehicle_items( vehicle &cur_veh, int part )
 
 void map::process_active_items()
 {
-    process_items( true );
+    process_items();
 }
 
 std::vector<tripoint> map::check_submap_active_item_consistency()
@@ -4447,7 +4447,7 @@ std::vector<tripoint> map::check_submap_active_item_consistency()
     return result;
 }
 
-void map::process_items( const bool active )
+void map::process_items()
 {
     const int minz = zlevels ? -OVERMAP_DEPTH : abs_sub.z;
     const int maxz = zlevels ? OVERMAP_HEIGHT : abs_sub.z;
@@ -4469,7 +4469,7 @@ void map::process_items( const bool active )
     for( const tripoint &abs_pos : submaps_with_active_items_copy ) {
         const tripoint local_pos = abs_pos - abs_sub.xy();
         submap *const current_submap = get_submap_at_grid( local_pos );
-        if( !active || !current_submap->active_items.empty() ) {
+        if( !current_submap->active_items.empty() ) {
             process_items_in_submap( *current_submap, local_pos );
         }
     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4416,11 +4416,6 @@ static void process_vehicle_items( vehicle &cur_veh, int part )
     }
 }
 
-void map::process_active_items()
-{
-    process_items();
-}
-
 std::vector<tripoint> map::check_submap_active_item_consistency()
 {
     std::vector<tripoint> result;

--- a/src/map.h
+++ b/src/map.h
@@ -1704,13 +1704,12 @@ class map
     private:
 
         // Iterates over every item on the map, passing each item to the provided function.
-        void process_items( bool active, map_process_func processor, const std::string &signal );
+        void process_items( bool active, const std::string &signal );
         void process_items_in_submap( submap &current_submap, const tripoint &gridp,
-                                      map::map_process_func processor, const std::string &signal );
-        void process_items_in_vehicles( submap &current_submap, int gridz,
-                                        map_process_func processor, const std::string &signal );
+                                      const std::string &signal );
+        void process_items_in_vehicles( submap &current_submap, int gridz, const std::string &signal );
         void process_items_in_vehicle( vehicle &cur_veh, submap &current_submap, int gridz,
-                                       map::map_process_func processor, const std::string &signal );
+                                       const std::string &signal );
 
         /** Enum used by functors in `function_over` to control execution. */
         enum iteration_state {

--- a/src/map.h
+++ b/src/map.h
@@ -1693,7 +1693,7 @@ class map
     private:
 
         // Iterates over every item on the map, passing each item to the provided function.
-        void process_items( bool active );
+        void process_items();
         void process_items_in_submap( submap &current_submap, const tripoint &gridp );
         void process_items_in_vehicles( submap &current_submap );
         void process_items_in_vehicle( vehicle &cur_veh, submap &current_submap );

--- a/src/map.h
+++ b/src/map.h
@@ -1693,12 +1693,10 @@ class map
     private:
 
         // Iterates over every item on the map, passing each item to the provided function.
-        void process_items( bool active, const std::string &signal );
-        void process_items_in_submap( submap &current_submap, const tripoint &gridp,
-                                      const std::string &signal );
-        void process_items_in_vehicles( submap &current_submap, int gridz, const std::string &signal );
-        void process_items_in_vehicle( vehicle &cur_veh, submap &current_submap, int gridz,
-                                       const std::string &signal );
+        void process_items( bool active );
+        void process_items_in_submap( submap &current_submap, const tripoint &gridp );
+        void process_items_in_vehicles( submap &current_submap );
+        void process_items_in_vehicle( vehicle &cur_veh, submap &current_submap );
 
         /** Enum used by functors in `function_over` to control execution. */
         enum iteration_state {

--- a/src/map.h
+++ b/src/map.h
@@ -1693,7 +1693,6 @@ class map
     private:
 
         // Iterates over every item on the map, passing each item to the provided function.
-        void process_items();
         void process_items_in_submap( submap &current_submap, const tripoint &gridp );
         void process_items_in_vehicles( submap &current_submap );
         void process_items_in_vehicle( vehicle &cur_veh, submap &current_submap );

--- a/src/map.h
+++ b/src/map.h
@@ -1687,11 +1687,11 @@ class map
         // Second argument refers to whether we have to get a roof (we're over an unpassable tile)
         // or can just return air because we bashed down an entire floor tile
         ter_id get_roof( const tripoint &p, bool allow_air );
-
-    private:
-
-        // Iterates over every item on the map, passing each item to the provided function.
+    
+    public:
         void process_items();
+    private:
+        // Iterates over every item on the map, passing each item to the provided function.
         void process_items_in_submap( submap &current_submap, const tripoint &gridp );
         void process_items_in_vehicles( submap &current_submap );
         void process_items_in_vehicle( vehicle &cur_veh, submap &current_submap );

--- a/src/map.h
+++ b/src/map.h
@@ -1690,17 +1690,6 @@ class map
         // or can just return air because we bashed down an entire floor tile
         ter_id get_roof( const tripoint &p, bool allow_air );
 
-    public:
-        /**
-         * Processor function pointer used in process_items and brethren.
-         *
-         * Note, typedefs should be discouraged because they tend to obfuscate
-         * code, but due to complexity, a template type makes it worse here.
-         * It's a really heinous function pointer so a typedef is the best
-         * solution in this instance.
-         */
-        using map_process_func = bool ( * )( item_stack &, safe_reference<item> &, const tripoint &,
-                                             const std::string &, float, temperature_flag );
     private:
 
         // Iterates over every item on the map, passing each item to the provided function.

--- a/src/map.h
+++ b/src/map.h
@@ -984,8 +984,6 @@ class map
             set_temperature( tripoint( p, abs_sub.z ), new_temperature );
         }
 
-        // Items
-        void process_active_items();
         // Returns points for all submaps with inconsistent state relative to
         // the list in map.  Used in tests.
         std::vector<tripoint> check_submap_active_item_consistency();
@@ -1693,6 +1691,7 @@ class map
     private:
 
         // Iterates over every item on the map, passing each item to the provided function.
+        void process_items();
         void process_items_in_submap( submap &current_submap, const tripoint &gridp );
         void process_items_in_vehicles( submap &current_submap );
         void process_items_in_vehicle( vehicle &cur_veh, submap &current_submap );

--- a/src/map.h
+++ b/src/map.h
@@ -1687,7 +1687,7 @@ class map
         // Second argument refers to whether we have to get a roof (we're over an unpassable tile)
         // or can just return air because we bashed down an entire floor tile
         ter_id get_roof( const tripoint &p, bool allow_air );
-    
+
     public:
         void process_items();
     private:


### PR DESCRIPTION
#### Summary

```SUMMARY: Infrastructure "Map item processing refactoring"```

#### Purpose of change

The chain of functions for processing items on map is weird and hard to follow.
There are also many things that are in there but do not do anything.

#### Describe the solution

* The processing functions pases along `processor` pointer to a function. The function is always the same `process_map_items` so this was pointless. Now they just call the function.
* There is a string signal passed around. It is not used anywhere for anything. Removed `signal`.
* z position is passed along in vehicle item processing but not used for anything. Removed `gridz`.
* Boolean in process_items is always true and was only used in an or statement where it did nothing. Removed the boolean.
* The only thing that `process_active_items` did was set the above unneeded boolean to true and then call `process_items`. Removed `process_active_items` and instead just call `process_items`. `process_items` was made public so it can be called.
* `process_item` always passes along a boolean false. Just have false in the final palce.
* `process_map_items` does nothing but call `process_item`. Replace `process_item` with `process_map_items`.

#### Describe alternatives you've considered

More refactoring.

#### Testing

Tests pass, items still get processed in inventory, on ground and in vehicles.

#### Additional context

