### PR TITLE
fix too mnay processing

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2349,6 +2349,18 @@ std::vector<item_location> Character::all_items_loc()
     return ret;
 }
 
+std::vector<item_location> Character::top_items_loc()
+{
+    std::vector<item_location> ret;
+    if( has_weapon() ) {
+        item_location weap_loc( *this, &weapon );
+    }
+    for( item &worn_it : worn ) {
+        item_location worn_loc( *this, &worn_it );
+    }
+    return ret;
+}
+
 item *Character::invlet_to_item( const int linvlet )
 {
     // Invlets may come from curses, which may also return any kind of key codes, those being

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2354,9 +2354,11 @@ std::vector<item_location> Character::top_items_loc()
     std::vector<item_location> ret;
     if( has_weapon() ) {
         item_location weap_loc( *this, &weapon );
+        ret.push_back( weap_loc );
     }
     for( item &worn_it : worn ) {
         item_location worn_loc( *this, &worn_it );
+        ret.push_back( worn_loc );
     }
     return ret;
 }

--- a/src/character.h
+++ b/src/character.h
@@ -1229,6 +1229,8 @@ class Character : public Creature, public visitable<Character>
         // returns a list of all item_location the character has, including items contained in other items.
         // only for CONTAINER pocket type; does not look for magazines
         std::vector<item_location> all_items_loc();
+		// Returns list of all the top level item_lodation the character has. Includes worn and held items.
+		std::vector<item_location> top_items_loc();
         /** Return the item pointer of the item with given invlet, return nullptr if
          * the player does not have such an item with that invlet. Don't use this on npcs.
          * Only use the invlet in the user interface, otherwise always use the item position. */

--- a/src/character.h
+++ b/src/character.h
@@ -1229,8 +1229,8 @@ class Character : public Creature, public visitable<Character>
         // returns a list of all item_location the character has, including items contained in other items.
         // only for CONTAINER pocket type; does not look for magazines
         std::vector<item_location> all_items_loc();
-		// Returns list of all the top level item_lodation the character has. Includes worn and held items.
-		std::vector<item_location> top_items_loc();
+        // Returns list of all the top level item_lodation the character has. Includes worn and held items.
+        std::vector<item_location> top_items_loc();
         /** Return the item pointer of the item with given invlet, return nullptr if
          * the player does not have such an item with that invlet. Don't use this on npcs.
          * Only use the invlet in the user interface, otherwise always use the item position. */

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8562,6 +8562,7 @@ void item::apply_freezerburn()
 bool item::process_temperature_rot( float insulation, const tripoint &pos,
                                     player *carrier, const temperature_flag flag, float spoil_modifier )
 {
+    debugmsg( _( "%s, insulation %f" ), tname(), insulation );
     const time_point now = calendar::turn;
 
     // if player debug menu'd the time backward it breaks stuff, just reset the
@@ -9375,7 +9376,8 @@ bool item::process_blackpowder_fouling( player *carrier )
 bool item::process( player *carrier, const tripoint &pos, bool activate, float insulation,
                     temperature_flag flag, float spoil_multiplier_parent )
 {
-    contents.process( carrier, pos, activate, insulation, flag, spoil_multiplier_parent );
+    contents.process( carrier, pos, activate, type->insulation_factor * insulation, flag,
+                      spoil_multiplier_parent );
     return process_internal( carrier, pos, activate, insulation, flag, spoil_multiplier_parent );
 }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8562,7 +8562,6 @@ void item::apply_freezerburn()
 bool item::process_temperature_rot( float insulation, const tripoint &pos,
                                     player *carrier, const temperature_flag flag, float spoil_modifier )
 {
-    debugmsg( _( "%s, insulation %f" ), tname(), insulation );
     const time_point now = calendar::turn;
 
     // if player debug menu'd the time backward it breaks stuff, just reset the
@@ -9376,8 +9375,7 @@ bool item::process_blackpowder_fouling( player *carrier )
 bool item::process( player *carrier, const tripoint &pos, bool activate, float insulation,
                     temperature_flag flag, float spoil_multiplier_parent )
 {
-    contents.process( carrier, pos, activate, type->insulation_factor * insulation, flag,
-                      spoil_multiplier_parent );
+    contents.process( carrier, pos, activate, insulation, flag, spoil_multiplier_parent );
     return process_internal( carrier, pos, activate, insulation, flag, spoil_multiplier_parent );
 }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1763,7 +1763,7 @@ void player::process_items()
     }
 
     std::vector<item_location> removed_items;
-    for( item_location it : all_items_loc() ) {
+    for( item_location it : top_items_loc() ) {
         if( !it ) {
             continue;
         }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1767,7 +1767,6 @@ void player::process_items()
         if( !it ) {
             continue;
         }
-        debugmsg( _( "%s" ), it->tname() );
         if( it->needs_processing() ) {
             if( it->process( this, pos(), false ) ) {
                 removed_items.push_back( it );

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1777,11 +1777,6 @@ void player::process_items()
         removed.remove_item();
     }
 
-    // worn items
-    remove_worn_items_with( [this]( item & itm ) {
-        return itm.needs_processing() && itm.process( this, pos(), false );
-    } );
-
     // Active item processing done, now we're recharging.
     item *cloak = nullptr;
     item *power_armor = nullptr;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1767,6 +1767,7 @@ void player::process_items()
         if( !it ) {
             continue;
         }
+        debugmsg( _( "%s" ), it->tname() );
         if( it->needs_processing() ) {
             if( it->process( this, pos(), false ) ) {
                 removed_items.push_back( it );


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix items inside items carried by player getting processed too many times"

#### Purpose of change

Fixes # 40868
When combined with # 40869 fixes # 40193

#### Describe the solution

Processing of items carried by player began by processing all items the player had, including items inside items.
Additionally when each item was processed the items inside it were also processed.
This resulted in items inside items being processed multiple times.

Solution is to process all top level items the player has. Items inside these items are processed when the container is processed.

There was also an extra processing done on all worn items. This is removed in "I do not think this does anything" commit. I do not  think it did anything and one guess was that it was old code from when things like headlamps were processed separately. If anyone has certain knowledge on what it does please say what it did.

#### Describe alternatives you've considered

#### Testing

Items inside items carrioed by player are processed only once.
Tested with water in thermos in pocket with some debugging messages.

#### Additional context


