### PR TITLE
remove unused rotten_away

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8744,18 +8744,6 @@ bool item::has_rotten_away() const
     }
 }
 
-bool item::has_rotten_away( const tripoint &pnt, float spoil_multiplier, temperature_flag flag )
-{
-    if( goes_bad() ) {
-        process_temperature_rot( 1, pnt, nullptr, flag, spoil_multiplier );
-        return has_rotten_away();
-    } else {
-        contents.remove_rotten( pnt );
-
-        return false;
-    }
-}
-
 bool item_ptr_compare_by_charges( const item *left, const item *right )
 {
     if( left->contents.empty() ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8982,11 +8982,8 @@ bool item::process_temperature_rot( float insulation, const tripoint &pos,
             }
 
             // Calculate item temperature from environment temperature
-            // If the time was more than 2 d ago just set the item to environment temperature
-            if( now - time > 2_days ) {
-                // This value shouldn't be there anymore after the loop is done so we don't bother with the set_item_temperature()
-                temperature = static_cast<int>( 100000 * temp_to_kelvin( env_temperature ) );
-            } else {
+            // If the time was more than 2 d ago we do not care about item temperature.
+            if( now - time < 2_days ) {
                 calc_temp( env_temperature, insulation, time_delta );
             }
             last_temp_check = time;

--- a/src/item.h
+++ b/src/item.h
@@ -787,15 +787,6 @@ class item : public visitable<item>
          * @param mod How many charges should be removed.
          */
         void mod_charges( int mod );
-        /**
-         * Whether the item has to be removed as it has rotten away completely. May change the item as it calls process_temperature_rot()
-         * @param pnt The *absolute* position of the item in the world (see @ref map::getabs),
-         * @param spoil_multiplier the multiplier for spoilage rate, based on what this item is inside of.
-         * used for rot calculation.
-         * @return true if the item has rotten away and should be removed, false otherwise.
-         */
-        bool has_rotten_away( const tripoint &pnt, float spoil_multiplier = 1.0f,
-                              temperature_flag flag = temperature_flag::NORMAL );
 
         /**
          * Accumulate rot of the item since last rot calculation.

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1223,16 +1223,6 @@ units::volume item_contents::total_contained_volume() const
     return total_vol;
 }
 
-void item_contents::remove_rotten( const tripoint &pnt )
-{
-    for( item_pocket &pocket : contents ) {
-        // no reason to check mods, they won't rot
-        if( !pocket.is_type( item_pocket::pocket_type::MOD ) ) {
-            pocket.remove_rotten( pnt );
-        }
-    }
-}
-
 void item_contents::remove_internal( const std::function<bool( item & )> &filter,
                                      int &count, std::list<item> &res )
 {

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -208,7 +208,6 @@ class item_contents
         bool has_any_with( const std::function<bool( const item & )> &filter,
                            item_pocket::pocket_type pk_type ) const;
 
-        void remove_rotten( const tripoint &pnt );
         /**
          * Is part of the recursive call of item::process. see that function for additional comments
          * NOTE: this destroys the items that get processed

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1214,17 +1214,6 @@ void item_pocket::has_rotten_away()
     }
 }
 
-void item_pocket::remove_rotten( const tripoint &pnt )
-{
-    for( auto iter = contents.begin(); iter != contents.end(); ) {
-        if( iter->has_rotten_away( pnt, spoil_multiplier() ) ) {
-            iter = contents.erase( iter );
-        } else {
-            ++iter;
-        }
-    }
-}
-
 void item_pocket::process( player *carrier, const tripoint &pos, float insulation,
                            temperature_flag flag, float spoil_multiplier_parent )
 {

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1203,17 +1203,6 @@ void item_pocket::remove_items_if( const std::function<bool( item & )> &filter )
     on_contents_changed();
 }
 
-void item_pocket::has_rotten_away()
-{
-    for( auto it = contents.begin(); it != contents.end(); ) {
-        if( it->has_rotten_away() ) {
-            it = contents.erase( it );
-        } else {
-            ++it;
-        }
-    }
-}
-
 void item_pocket::process( player *carrier, const tripoint &pos, float insulation,
                            temperature_flag flag, float spoil_multiplier_parent )
 {

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -218,7 +218,6 @@ class item_pocket
         bool has_item( const item &it ) const;
         item *get_item_with( const std::function<bool( const item & )> &filter );
         void remove_items_if( const std::function<bool( item & )> &filter );
-        void has_rotten_away();
         /**
          * Is part of the recursive call of item::process. see that function for additional comments
          * NOTE: this destroys the items that get processed

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -219,7 +219,6 @@ class item_pocket
         item *get_item_with( const std::function<bool( const item & )> &filter );
         void remove_items_if( const std::function<bool( item & )> &filter );
         void has_rotten_away();
-        void remove_rotten( const tripoint &pnt );
         /**
          * Is part of the recursive call of item::process. see that function for additional comments
          * NOTE: this destroys the items that get processed


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Remove unused and unecessary code"

#### Purpose of change

Remove unused stuff.

#### Describe the solution

`item::has_rotten_away` (the other one), `item_pocket::has_rotten_away`, `item_contents::remove_rotten` and `item_pocket::remove_rotten` were not used anywhere. Simply removed them.

Item temperature from more than 2d ago was not used for anything. It is no longer set.

#### Describe alternatives you've considered

Leave it be.

#### Testing

It compiles.
It plays.

#### Additional context

