### PR TITLE
old gunfaults

### DIFF
--- a/data/json/items/gun/faults_gun.json
+++ b/data/json/items/gun/faults_gun.json
@@ -57,7 +57,7 @@
         }
       }
     ],
-    "flags": [ "SILENT" ]
+    "flags": [ "SILENT", "BLACKPOWDER_FOULING", "NO_DIRTYING" ]
   },
   {
     "id": "fault_gun_chamber_spent",
@@ -73,7 +73,8 @@
         "skills": [  ],
         "requirements": {  }
       }
-    ]
+    ],
+    "flags": [ "JAMMED_GUN" ]
   },
   {
     "id": "fault_gun_unlubricated",
@@ -96,7 +97,8 @@
           ]
         }
       }
-    ]
+    ],
+    "flags": [ "UNLUBRICATED", "BAD_CYCLING" ]
   },
   {
     "id": "fault_gun_dirt",

--- a/data/json/items/gun/faults_gun.json
+++ b/data/json/items/gun/faults_gun.json
@@ -57,7 +57,7 @@
         }
       }
     ],
-    "flags": [ "SILENT", "BLACKPOWDER_FOULING", "NO_DIRTYING" ]
+    "flags": [ "SILENT", "BLACKPOWDER_FOULING_DAMAGE", "NO_DIRTYING" ]
   },
   {
     "id": "fault_gun_chamber_spent",

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -1492,7 +1492,10 @@ The requirement for other vehicle parts is defined for a json flag by setting ``
 
 #### Flags
 
+General fault flag:
 - ```SILENT``` Makes the "faulty " text NOT appear next to item on general UI. Otherwise the fault works the same.
+
+Vehicle fault flags:
 - ```NO_ALTERNATOR_CHARGE``` The alternator connected to this engine does not work.
 - ```BAD_COLD_START``` The engine starts as if the themperature was 20 F colder. Does not stack with multiples of itself.
 - ```IMMOBILIZER``` Prevents engine from starting and makes it beeb.
@@ -1503,6 +1506,12 @@ The requirement for other vehicle parts is defined for a json flag by setting ``
 - ```REDUCE_ENG_POWER``` Multiplies engine power by 0.6. Does not stack with multiples of itself.
 - ```ENG_BACKFIRE``` Causes the engine to backfire as if it had zero hp.
 
+Gun fault flags:
+- ```BLACKPOWDER_FOULING_DAMAGE``` Causes the gun to take random acid damage.
+- ```NO_DIRTYING``` Prevents the gun from receiving `fault_gun_dirt` fault.
+- ```JAMMED_GUN``` Stops burst fire. Adds delay on next shot.
+- ```UNLUBRICATED``` Randomly causes screeching noise when firing and applies damage when that happens.
+- ```BAD_CYCLING``` One in 16 chance that the gun fails to cycle when fired resulting in `fault_gun_chamber_spent` fault.
 
 #### Parameters
 

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -69,6 +69,7 @@
     - [Fuel types](#fuel-types)
   - [Faults](#faults)
     - [Flags](#flags-13)
+    - [Parameters](#parameters)
 
 ## Notes
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9896,7 +9896,7 @@ bool item::process_internal( player *carrier, const tripoint &pos,
         return processed;
     }
 
-    if( has_fault_flag( "BLACKPOWDER_FOULING" ) ) {
+    if( has_fault_flag( "BLACKPOWDER_FOULING_DAMAGE" ) ) {
         return process_blackpowder_fouling( carrier );
     }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -115,8 +115,6 @@ static const efftype_id effect_sleep( "sleep" );
 static const efftype_id effect_weed_high( "weed_high" );
 static const efftype_id effect_bleed( "bleed" );
 
-static const fault_id fault_gun_blackpowder( "fault_gun_blackpowder" );
-
 static const gun_mode_id gun_mode_REACH( "REACH" );
 
 static const itype_id itype_battery( "battery" );
@@ -9898,7 +9896,7 @@ bool item::process_internal( player *carrier, const tripoint &pos,
         return processed;
     }
 
-    if( faults.count( fault_gun_blackpowder ) ) {
+    if( has_fault_flag( "BLACKPOWDER_FOULING" ) ) {
         return process_blackpowder_fouling( carrier );
     }
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -656,8 +656,8 @@ bool player::handle_gun_damage( item &it )
         if( !curammo_effects.count( "NON-FOULING" ) && !it.has_flag( flag_NON_FOULING ) ) {
             bool black_powder_ammo = curammo_effects.count( "BLACKPOWDER" );
             if( dirt < static_cast<int>( dirt_max_dbl ) ) {
-                dirtadder = black_powder_ammo * ( 200 - ( firing.blackpowder_tolerance *
-                                                  2 ) );
+                dirtadder = black_powder_ammo * ( 200 - firing.blackpowder_tolerance *
+                                                  2 );
                 // dirtadder is the dirt-increasing number for shots fired with gunpowder-based ammo. Usually dirt level increases by 1, unless it's blackpowder, in which case it increases by a higher number, but there is a reduction for blackpowder resistance of a weapon.
                 if( dirtadder < 0 ) {
                     dirtadder = 0;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -96,7 +96,6 @@ static const trap_str_id tr_practice_target( "tr_practice_target" );
 static const fault_id fault_gun_blackpowder( "fault_gun_blackpowder" );
 static const fault_id fault_gun_chamber_spent( "fault_gun_chamber_spent" );
 static const fault_id fault_gun_dirt( "fault_gun_dirt" );
-static const fault_id fault_gun_unlubricated( "fault_gun_unlubricated" );
 
 static const skill_id skill_dodge( "dodge" );
 static const skill_id skill_driving( "driving" );
@@ -544,7 +543,7 @@ bool player::handle_gun_damage( item &it )
     int dirt = it.get_var( "dirt", 0 );
     int dirtadder = 0;
     double dirt_dbl = static_cast<double>( dirt );
-    if( it.faults.count( fault_gun_chamber_spent ) ) {
+    if( it.has_fault_flag( "JAMMED_GUN" ) ) {
         return false;
     }
 
@@ -635,7 +634,7 @@ bool player::handle_gun_damage( item &it )
             }
         }
     }
-    if( it.has_fault( fault_gun_unlubricated ) &&
+    if( it.has_fault_flag( "UNLUBRICATED" ) &&
         x_in_y( dirt_dbl, dirt_max_dbl ) ) {
         add_msg_player_or_npc( m_bad, _( "Your %s emits a grimace-inducing screech!" ),
                                _( "<npcname>'s %s emits a grimace-inducing screech!" ),
@@ -643,12 +642,12 @@ bool player::handle_gun_damage( item &it )
         it.inc_damage();
     }
     if( ( ( !curammo_effects.count( "NON-FOULING" ) && !it.has_flag( flag_NON_FOULING ) ) ||
-          ( it.has_fault( fault_gun_unlubricated ) ) ) &&
+          ( it.has_fault_flag( "BAD_CYCLING" ) ) ) &&
         !it.has_flag( flag_PRIMITIVE_RANGED_WEAPON ) ) {
         if( curammo_effects.count( "BLACKPOWDER" ) ||
-            it.has_fault( fault_gun_unlubricated ) ) {
+            it.has_fault_flag( "BAD_CYCLING" ) ) {
             if( ( ( it.ammo_data()->ammo->recoil < firing.min_cycle_recoil ) ||
-                  ( it.has_fault( fault_gun_unlubricated ) && one_in( 16 ) ) ) &&
+                  ( it.has_fault_flag( "BAD_CYCLING" ) && one_in( 16 ) ) ) &&
                 it.faults_potential().count( fault_gun_chamber_spent ) ) {
                 add_msg_player_or_npc( m_bad, _( "Your %s fails to cycle!" ),
                                        _( "<npcname>'s %s fails to cycle!" ),
@@ -674,7 +673,7 @@ bool player::handle_gun_damage( item &it )
             }
             dirt = it.get_var( "dirt", 0 );
             dirt_dbl = static_cast<double>( dirt );
-            if( dirt > 0 && !it.faults.count( fault_gun_blackpowder ) ) {
+            if( dirt > 0 && !it.has_fault_flag( "NO_DIRTYING" ) ) {
                 it.faults.insert( fault_gun_dirt );
             }
             if( dirt > 0 && curammo_effects.count( "BLACKPOWDER" ) ) {
@@ -770,7 +769,7 @@ int player::fire_gun( const tripoint &target, int shots, item &gun )
     int hits = 0; // total shots on target
     int delay = 0; // delayed recoil that has yet to be applied
     while( curshot != shots ) {
-        if( gun.faults.count( fault_gun_chamber_spent ) && curshot == 0 ) {
+        if( gun.has_fault_flag( "JAMMED_GUN" ) && curshot == 0 ) {
             moves -= 50;
             gun.faults.erase( fault_gun_chamber_spent );
             add_msg_if_player( _( "You cycle your %s manually." ), gun.tname() );


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Apply fault effects with flags instead of fault id"

#### Purpose of change

Faults apply various effects.

This was done by checking the id of the fault. 
As a result all effects were hardcoded to only come from that specific fault, each fault had one hardcoded effect and the faults could not be modded in json.

Now it is done by checking what flags the fault has.

This doesn't really change anything currently. But this will make faults more flexible.

#### Describe the solution

Instead of checking "Does any of the faults have [id]" check for "Does any of the faults have [flag]".

The logic for applying fouling and cycle failures was partially rewritten. The old one had repeated statements checking same things multiple times.  
It was also possible to fire non-blacpowder ammo  with too low recoil without getting failed cycling faults. Now that is fixed.

#### Describe alternatives you've considered


#### Testing



#### Additional context

