### PR TITLE
refactor rotpoints

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5940,17 +5940,16 @@ float item::get_hourly_rotpoints_at_temp( const int temp ) const
     } else if( temp < dropoff ) {
         // Linear progress from 32 F (0 C) to 38 F (3 C)
         // Constant makes sure that rot function is continuous at 38 F
-        // The constand 305.065 = rot(38 F) / ( 38 F - 32 F) = ( 218.13 * ( 38 / 16 )^2 ) / 6
-        return 305.06509f * ( temp - temperatures::freezing );
+        // The constand 186.28 = rot(38 F) / ( 38 F - 32 F) = ( 215.46 * 2^( 38 / 16 ) ) / 6
+        return 186.27867f * ( temp - temperatures::freezing );
     } else if( temp < max_rot_temp ) {
         // This multiplier makes sure the rot at 65 F (18 C) is 3600 rot/hour (1 rot/second).
-        // the multiplier is calculated 218.13018f = 3600 / ( 65 / 16 )^2
-        const float temp_ratio = temp / 16.0f;
-        return 218.13018f * temp_ratio * temp_ratio;
+        // the multiplier is calculated 218.13018f = 3600 / 2^( 65 / 16 )
+        return 215.4607 * std::pow( 2.0, static_cast<double>( temp ) / 16.0 );
     } else {
         // stop torturing the player at max_rot_temp (105 F, 41 C). No higher rot at higher temp.
-        // This is calculated from:  multiplier * ( 105 / 16.0 )^2
-        return 9394.0828f;
+        // This is calculated from:  multiplier * 2^( 105 / 16.0 )
+        return 20364.6753f;
     }
 }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5938,7 +5938,7 @@ float item::get_hourly_rotpoints_at_temp( const int temp )
         // Linear progress from 32 F (0 C) to 38 F (3 C)
         // The constand d is calculated from: multiplier * std::pow( 2.0, 38.0 / 16.0 );
         const float d = 1117.672;
-        return temp * d / 6 + d * 16 / 6;
+        return d / 6 * ( temp - temperatures::freezing );
     } else if( temp < max_rot_temp ) {
         // This multiplier makes sure the rot at 65 F (18 C) is 3600 rot/hour (1 rot/second).
         // the multiplier is calculated from: 3600 / std::pow( 2.0, 65.0 / 16.0 );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5931,8 +5931,9 @@ float item::get_hourly_rotpoints_at_temp( const int temp )
 {
     const float dropoff = 38;  // ~3 C
     const float max_rot_temp = 105; // ~41 C Maximum rotting rate is at this temperature
+	const float safe_temp = 145; // ~63 C safe temperature at which food stops rotting
 
-    if( temp <= temperatures::freezing ) {
+    if( temp <= temperatures::freezing || temp > safe_temp ) {
         return 0;
     } else if( temp < dropoff ) {
         // Linear progress from 32 F (0 C) to 38 F (3 C)

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5934,7 +5934,6 @@ static float calc_hourly_rotpoints_at_temp( const int temp )
     // ~3 C ditch our fancy equation and do a linear approach to 0 rot from 3 C -> 0 C
     const int max_rot_temp = 105; // ~41 C Maximum rotting rate is at this temperature
     const int safe_temp = 145; // ~63 C safe temperature above which food stops rotting
-    // temperatures::freezing = 32 F ( 0 C)
 
     if( temp <= temperatures::freezing || temp > safe_temp ) {
         return 0.0;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5956,15 +5956,14 @@ static float calc_hourly_rotpoints_at_temp( const double temp )
     }
 }
 
-/**
- * Initialize the rot table.
- * @see rot_chart
- */
+
 static std::vector<float> calc_rot_array()
 {
+	// Array with precalculated rot rates
+	// Includes temperatures from 0 F ( -18C) to 145 F (63 F)
     std::vector<float> ret;
-    ret.reserve( 145 );
-    for( size_t i = 0; i < 145; ++i ) {
+    ret.reserve( 146 );
+    for( size_t i = 0; i < 146; ++i ) {
         ret.push_back( calc_hourly_rotpoints_at_temp( i ) );
     }
     return ret;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5926,6 +5926,7 @@ int item::spoilage_sort_order() const
  * Rate of rot doubles every 16 F increase in temperature
  * Rate of rot halves every 16 F decrease in temperature
  * Rot maxes out at 105 F
+ * Rot stops below 32 F (0C) and above 145 F (63 C)
  */
 float item::get_hourly_rotpoints_at_temp( const int temp )
 {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5959,8 +5959,8 @@ static float calc_hourly_rotpoints_at_temp( const double temp )
 
 static std::vector<float> calc_rot_array()
 {
-	// Array with precalculated rot rates
-	// Includes temperatures from 0 F ( -18C) to 145 F (63 F)
+    // Array with precalculated rot rates
+    // Includes temperatures from 0 F ( -18C) to 145 F (63 F)
     std::vector<float> ret;
     ret.reserve( 146 );
     for( size_t i = 0; i < 146; ++i ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5936,20 +5936,19 @@ static float calc_hourly_rotpoints_at_temp( const int temp )
     const int safe_temp = 145; // ~63 C safe temperature above which food stops rotting
 
     if( temp <= temperatures::freezing || temp > safe_temp ) {
-        return 0.0;
+        return 0.f;
     } else if( temp < dropoff ) {
         // Linear progress from 32 F (0 C) to 38 F (3 C)
-        return 600.0 * std::pow( 2.0, -27.0 / 16.0 ) * ( temp - temperatures::freezing );
+        return 600.f * std::pow( 2.f, -27.f / 16.f ) * ( temp - temperatures::freezing );
     } else if( temp < max_rot_temp ) {
         // Exponential progress from 38 F (3 C) to 105 F (41 C)
-        return 3600.0 * std::pow( 2.0, ( temp - 65.0 ) / 16.0 );
+        return 3600.f * std::pow( 2.f, ( temp - 65.f ) / 16.f );
     } else {
         // Constant rot from 105 F (41 C) to 145 F (63 C)
         // This is approximately 20364.67 rot/hour
-        return 3600.0 * std::pow( 2.0, ( max_rot_temp - 65.0 ) / 16.0 );
+        return 3600.f * std::pow( 2.f, ( max_rot_temp - 65.f ) / 16.f );
     }
 }
-
 
 static std::vector<float> calc_rot_array()
 {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5956,7 +5956,7 @@ static std::vector<float> calc_rot_array()
     // Includes temperatures from 0 F ( -18C) to 145 F (63 F)
     std::vector<float> ret;
     ret.reserve( 146 );
-    for( size_t i = 0; i < 146; ++i ) {
+    for( int i = 0; i < 146; ++i ) {
         ret.push_back( calc_hourly_rotpoints_at_temp( i ) );
     }
     return ret;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5922,7 +5922,7 @@ int item::spoilage_sort_order() const
 
 /**
  * Food decay calculation.
- * Calculate how much food rots per hour, based on 3600 rot/hour at 65 F.
+ * Calculate how much food rots per hour, based on 3600 rot/hour at 65 F (18.3 C).
  * Rate of rot doubles every 16 F increase in temperature
  * Rate of rot halves every 16 F decrease in temperature
  * Rot maxes out at 105 F

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5939,14 +5939,14 @@ static float calc_hourly_rotpoints_at_temp( const int temp )
         return 0.f;
     } else if( temp < dropoff ) {
         // Linear progress from 32 F (0 C) to 38 F (3 C)
-        return 600.f * std::pow( 2.f, -27.f / 16.f ) * ( temp - temperatures::freezing );
+        return 600.f * std::exp2( -27.f / 16.f ) * ( temp - temperatures::freezing );
     } else if( temp < max_rot_temp ) {
         // Exponential progress from 38 F (3 C) to 105 F (41 C)
-        return 3600.f * std::pow( 2.f, ( temp - 65.f ) / 16.f );
+        return 3600.f * std::exp2( ( temp - 65.f ) / 16.f );
     } else {
         // Constant rot from 105 F (41 C) to 145 F (63 C)
         // This is approximately 20364.67 rot/hour
-        return 3600.f * std::pow( 2.f, ( max_rot_temp - 65.f ) / 16.f );
+        return 3600.f * std::exp2( ( max_rot_temp - 65.f ) / 16.f );
     }
 }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5941,7 +5941,7 @@ static float calc_hourly_rotpoints_at_temp( const int temp )
         // Linear progress from 32 F (0 C) to 38 F (3 C)
         return 600.0 * std::pow( 2.0, -27.0 / 16.0 ) * ( temp - temperatures::freezing );
     } else if( temp < max_rot_temp ) {
-        // Exponential progress from 48 F (3 C) to 105 F (41 C)
+        // Exponential progress from 38 F (3 C) to 105 F (41 C)
         return 3600.0 * std::pow( 2.0, ( temp - 65.0 ) / 16.0 );
     } else {
         // Constant rot from 105 F (41 C) to 145 F (63 C)

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5922,7 +5922,7 @@ int item::spoilage_sort_order() const
 
 /**
  * Food decay calculation.
- * Calculate how much food rots per hour, based on 1 rot/second at 65 F.
+ * Calculate how much food rots per hour, based on 3600 rot/hour at 65 F.
  * Rate of rot doubles every 16 F increase in temperature
  * Rate of rot halves every 16 F decrease in temperature
  * Rot maxes out at 105 F
@@ -5933,18 +5933,19 @@ float get_hourly_rotpoints_at_temp( const int temp )
     const float max_rot_temp = 105; // Maximum rotting rate is at this temperature
 
     // This multiplier makes sure the rot at 65 F (18 C) is 3600 rot/hour (1 rot/second).
-    // This is approximately 215.46
-    const float multiplier = 3600 / std::pow( 2.0, 65.0 / 16.0 );
+    // the multiplier is calculated from: 3600 / std::pow( 2.0, 65.0 / 16.0 );
+    const float multiplier = 215.4607
 
     if( temp <= temperatures::freezing ) {
         return 0;
     } else if( temp > max_rot_temp ) {
         // stop torturing the player at 105 F (41 C). No higher rot at higher temp.
-        // This is approx 20364 rot/hour
-        return multiplier * std::pow( 2.0, max_rot_temp / 10.0 );
+        // This is calculated from:  multiplier * std::pow( 2.0, max_rot_temp / 16.0 );
+        return 20364.6753;
     } else if( temp < dropoff ) {
         // Linear progress from 32 F (0 C) to 38 F (3 C)
-        const float d = multiplier * std::pow( 2.0, 38.0 / 16.0 );
+        // The constand d is calculated from: multiplier * std::pow( 2.0, 38.0 / 16.0 );
+        const float d = 1117.672;
         return temp * d / 6 + d * 16 / 6;
     } else {
         return multiplier * std::pow( 2.0, static_cast<float>( temp ) / 16.0 );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5934,7 +5934,7 @@ float get_hourly_rotpoints_at_temp( const int temp )
 
     // This multiplier makes sure the rot at 65 F (18 C) is 3600 rot/hour (1 rot/second).
     // the multiplier is calculated from: 3600 / std::pow( 2.0, 65.0 / 16.0 );
-    const float multiplier = 215.4607
+    const float multiplier = 215.4607;
 
     if( temp <= temperatures::freezing ) {
         return 0;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5928,12 +5928,12 @@ int item::spoilage_sort_order() const
  * Rot maxes out at 105 F
  * Rot stops below 32 F (0C) and above 145 F (63 C)
  */
-static float calc_hourly_rotpoints_at_temp( const double temp )
+static float calc_hourly_rotpoints_at_temp( const int temp )
 {
-    const double dropoff = 38;
+    const int dropoff = 38;
     // ~3 C ditch our fancy equation and do a linear approach to 0 rot from 3 C -> 0 C
-    const double max_rot_temp = 105; // ~41 C Maximum rotting rate is at this temperature
-    const double safe_temp = 145; // ~63 C safe temperature above which food stops rotting
+    const int max_rot_temp = 105; // ~41 C Maximum rotting rate is at this temperature
+    const int safe_temp = 145; // ~63 C safe temperature above which food stops rotting
     // temperatures::freezing = 32 F ( 0 C)
 
     if( temp <= temperatures::freezing || temp > safe_temp ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5932,7 +5932,7 @@ float item::get_hourly_rotpoints_at_temp( const int temp )
 {
     const float dropoff = 38;  // ~3 C
     const float max_rot_temp = 105; // ~41 C Maximum rotting rate is at this temperature
-	const float safe_temp = 145; // ~63 C safe temperature at which food stops rotting
+    const float safe_temp = 145; // ~63 C safe temperature at which food stops rotting
 
     if( temp <= temperatures::freezing || temp > safe_temp ) {
         return 0;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5944,7 +5944,7 @@ float item::get_hourly_rotpoints_at_temp( const int temp ) const
         return 186.27867f * ( temp - temperatures::freezing );
     } else if( temp < max_rot_temp ) {
         // This multiplier makes sure the rot at 65 F (18 C) is 3600 rot/hour (1 rot/second).
-        // the multiplier is calculated 218.13018f = 3600 / 2^( 65 / 16 )
+        // the multiplier is calculated 215.46 = 3600 / 2^( 65 / 16 )
         return 215.4607 * std::pow( 2.0, static_cast<double>( temp ) / 16.0 );
     } else {
         // stop torturing the player at max_rot_temp (105 F, 41 C). No higher rot at higher temp.

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5927,28 +5927,27 @@ int item::spoilage_sort_order() const
  * Rate of rot halves every 16 F decrease in temperature
  * Rot maxes out at 105 F
  */
-float get_hourly_rotpoints_at_temp( const int temp )
+float item::get_hourly_rotpoints_at_temp( const int temp )
 {
-    const float dropoff = 38;
-    const float max_rot_temp = 105; // Maximum rotting rate is at this temperature
-
-    // This multiplier makes sure the rot at 65 F (18 C) is 3600 rot/hour (1 rot/second).
-    // the multiplier is calculated from: 3600 / std::pow( 2.0, 65.0 / 16.0 );
-    const float multiplier = 215.4607;
+    const float dropoff = 38;  // ~3 C
+    const float max_rot_temp = 105; // ~41 C Maximum rotting rate is at this temperature
 
     if( temp <= temperatures::freezing ) {
         return 0;
-    } else if( temp > max_rot_temp ) {
-        // stop torturing the player at 105 F (41 C). No higher rot at higher temp.
-        // This is calculated from:  multiplier * std::pow( 2.0, max_rot_temp / 16.0 );
-        return 20364.6753;
     } else if( temp < dropoff ) {
         // Linear progress from 32 F (0 C) to 38 F (3 C)
         // The constand d is calculated from: multiplier * std::pow( 2.0, 38.0 / 16.0 );
         const float d = 1117.672;
         return temp * d / 6 + d * 16 / 6;
-    } else {
+    } else if( temp < max_rot_temp ) {
+        // This multiplier makes sure the rot at 65 F (18 C) is 3600 rot/hour (1 rot/second).
+        // the multiplier is calculated from: 3600 / std::pow( 2.0, 65.0 / 16.0 );
+        const float multiplier = 215.4607;
         return multiplier * std::pow( 2.0, static_cast<float>( temp ) / 16.0 );
+    } else {
+        // stop torturing the player at 105 F (41 C). No higher rot at higher temp.
+        // This is calculated from:  multiplier * std::pow( 2.0, max_rot_temp / 16.0 );
+        return 20364.6753;
     }
 }
 
@@ -7621,7 +7620,8 @@ void item::mark_chapter_as_read( const Character &u )
     set_var( var, remain );
 }
 
-std::vector<std::pair<const recipe *, int>> item::get_available_recipes( const Character &u ) const
+std::vector<std::pair<const recipe *, int>> item::get_available_recipes(
+            const Character &u ) const
 {
     std::vector<std::pair<const recipe *, int>> recipe_entries;
     if( is_book() ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5930,29 +5930,24 @@ int item::spoilage_sort_order() const
  */
 static float calc_hourly_rotpoints_at_temp( const double temp )
 {
-    const double dropoff =
-        38;  // ~3 C ditch our fancy equation and do a linear approach to 0 rot from 3 C -> 0 C
+    const double dropoff = 38;
+    // ~3 C ditch our fancy equation and do a linear approach to 0 rot from 3 C -> 0 C
     const double max_rot_temp = 105; // ~41 C Maximum rotting rate is at this temperature
     const double safe_temp = 145; // ~63 C safe temperature above which food stops rotting
     // temperatures::freezing = 32 F ( 0 C)
-
-    // This multiplier makes sure the rot at 65 F (18.3 C) C is 3600 rot/hour (1 rot/second).
-    // This is approximately 215.5
-    const double multiplier = 3600.0 / std::pow( 2.0, 65.0 / 16.0 );
 
     if( temp <= temperatures::freezing || temp > safe_temp ) {
         return 0.0;
     } else if( temp < dropoff ) {
         // Linear progress from 32 F (0 C) to 38 F (3 C)
-        // Constant makes sure that rot function is continuous at 38 F
-        // The constand 186.28 = ( multiplier * 2^( 38F / 16F ) ) / 6
-        return 186.27867 * ( temp - temperatures::freezing );
+        return 600.0 * std::pow( 2.0, -27.0 / 16.0 ) * ( temp - temperatures::freezing );
     } else if( temp < max_rot_temp ) {
-        return multiplier * std::pow( 2.0, temp / 16.0 );
+        // Exponential progress from 48 F (3 C) to 105 F (41 C)
+        return 3600.0 * std::pow( 2.0, ( temp - 65.0 ) / 16.0 );
     } else {
-        // stop torturing the player at max_rot_temp (105 F, 41 C). No higher rot at higher temp.
+        // Constant rot from 105 F (41 C) to 145 F (63 C)
         // This is approximately 20364.67 rot/hour
-        return multiplier * std::pow( 2.0, max_rot_temp / 16.0 );
+        return 3600.0 * std::pow( 2.0, ( max_rot_temp - 65.0 ) / 16.0 );
     }
 }
 

--- a/src/item.h
+++ b/src/item.h
@@ -841,6 +841,12 @@ class item : public visitable
          */
         void mod_charges( int mod );
 
+
+        /**
+        * Calculates rot per hour at given temperature.
+        */
+        float get_hourly_rotpoints_at_temp( int temp );
+
         /**
          * Accumulate rot of the item since last rot calculation.
          * This function should not be called directly. since it does not have all the needed checks or temperature calculations.

--- a/src/item.h
+++ b/src/item.h
@@ -845,7 +845,7 @@ class item : public visitable
         /**
         * Calculates rot per hour at given temperature.
         */
-        float get_hourly_rotpoints_at_temp( int temp ) const;
+        float get_hourly_rotpoints_at_temp( const int temp ) const;
 
         /**
          * Accumulate rot of the item since last rot calculation.

--- a/src/item.h
+++ b/src/item.h
@@ -845,7 +845,7 @@ class item : public visitable
         /**
         * Calculates rot per hour at given temperature.
         */
-        float get_hourly_rotpoints_at_temp( int temp );
+        float get_hourly_rotpoints_at_temp( int temp ) const;
 
         /**
          * Accumulate rot of the item since last rot calculation.

--- a/src/weather.h
+++ b/src/weather.h
@@ -131,10 +131,6 @@ std::string get_wind_arrow( int );
 std::string get_wind_desc( double );
 
 nc_color get_wind_color( double );
-/**
-* Calculates rot per hour at given temperature. Reference in weather_data.cpp
-*/
-float get_hourly_rotpoints_at_temp( int temp );
 
 /**
  * Is it warm enough to plant seeds?

--- a/src/weather.h
+++ b/src/weather.h
@@ -135,6 +135,7 @@ nc_color get_wind_color( double );
 * Calculates rot per hour at given temperature. Reference in weather_data.cpp
 */
 int get_hourly_rotpoints_at_temp( int temp );
+float get_hourly_rotpoints_at_temp2( int temp );
 
 /**
  * Is it warm enough to plant seeds?

--- a/src/weather.h
+++ b/src/weather.h
@@ -134,8 +134,7 @@ nc_color get_wind_color( double );
 /**
 * Calculates rot per hour at given temperature. Reference in weather_data.cpp
 */
-int get_hourly_rotpoints_at_temp( int temp );
-float get_hourly_rotpoints_at_temp2( int temp );
+float get_hourly_rotpoints_at_temp( int temp );
 
 /**
  * Is it warm enough to plant seeds?

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -111,6 +111,9 @@ TEST_CASE( "Hourly rotpoints", "[rot]" )
 
     // Doubles after +16F
     CHECK( normal_item.get_hourly_rotpoints_at_temp( 65 + 16 ) == Approx( 3600 * 2 ).margin( 0.1 ) );
+	
+	// Halves after -16F
+    CHECK( normal_item.get_hourly_rotpoints_at_temp( 65 - 16 ) == Approx( 3600 / 2 ).margin( 0.1 ) );
 
     // Test the linear area. Halfway between 32F/9C (0 point/hour) and 38F/3C (1117.672 point/hour)
     CHECK( normal_item.get_hourly_rotpoints_at_temp( 35 ) == Approx( 1117.672 / 2 ).margin( 0.1 ) );

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -119,5 +119,5 @@ TEST_CASE( "Hourly rotpoints", "[rot]" )
     CHECK( normal_item.get_hourly_rotpoints_at_temp( 35 ) == Approx( 1117.672 / 2 ).margin( 0.1 ) );
 
     // Maximum rot at above 105 F
-    CHECK( normal_item.get_hourly_rotpoints_at_temp( 107 ) == Approx( 20364.6753 ).margin( 0.1 ) );
+    CHECK( normal_item.get_hourly_rotpoints_at_temp( 107 ) == Approx( 9394.08 ).margin( 0.1 ) );
 }

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -119,5 +119,5 @@ TEST_CASE( "Hourly rotpoints", "[rot]" )
     CHECK( normal_item.get_hourly_rotpoints_at_temp( 35 ) == Approx( 1117.672 / 2 ).margin( 0.1 ) );
 
     // Maximum rot at above 105 F
-    CHECK( normal_item.get_hourly_rotpoints_at_temp( 107 ) == Approx( 9394.08 ).margin( 0.1 ) );
+    CHECK( normal_item.get_hourly_rotpoints_at_temp( 107 ) == Approx( 20364.67 ).margin( 0.1 ) );
 }

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -111,8 +111,8 @@ TEST_CASE( "Hourly rotpoints", "[rot]" )
 
     // Doubles after +16F
     CHECK( normal_item.get_hourly_rotpoints_at_temp( 65 + 16 ) == Approx( 3600 * 2 ).margin( 0.1 ) );
-	
-	// Halves after -16F
+
+    // Halves after -16F
     CHECK( normal_item.get_hourly_rotpoints_at_temp( 65 - 16 ) == Approx( 3600 / 2 ).margin( 0.1 ) );
 
     // Test the linear area. Halfway between 32F/9C (0 point/hour) and 38F/3C (1117.672 point/hour)

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -106,14 +106,18 @@ TEST_CASE( "Hourly rotpoints", "[rot]" )
     // No rot above 145F/63C
     CHECK( normal_item.get_hourly_rotpoints_at_temp( 150 ) == 0 );
 
+    // Make sure no off by one error at the border
+    CHECK( normal_item.get_hourly_rotpoints_at_temp( 145 ) == Approx( 20364.67 ).margin( 0.1 ) );
+    CHECK( normal_item.get_hourly_rotpoints_at_temp( 146 ) == 0 );
+
     // 3200 point/h at 65F/18C
     CHECK( normal_item.get_hourly_rotpoints_at_temp( 65 ) == Approx( 3600 ).margin( 0.1 ) );
 
     // Doubles after +16F
-    CHECK( normal_item.get_hourly_rotpoints_at_temp( 65 + 16 ) == Approx( 3600 * 2 ).margin( 0.1 ) );
+    CHECK( normal_item.get_hourly_rotpoints_at_temp( 65 + 16 ) == Approx( 3600.0 * 2 ).margin( 0.1 ) );
 
     // Halves after -16F
-    CHECK( normal_item.get_hourly_rotpoints_at_temp( 65 - 16 ) == Approx( 3600 / 2 ).margin( 0.1 ) );
+    CHECK( normal_item.get_hourly_rotpoints_at_temp( 65 - 16 ) == Approx( 3600.0 / 2 ).margin( 0.1 ) );
 
     // Test the linear area. Halfway between 32F/9C (0 point/hour) and 38F/3C (1117.672 point/hour)
     CHECK( normal_item.get_hourly_rotpoints_at_temp( 35 ) == Approx( 1117.672 / 2 ).margin( 0.1 ) );

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -12,7 +12,7 @@ static void set_map_temperature( int new_temperature )
     get_weather().clear_temp_cache();
 }
 
-TEST_CASE( "Rate of rotting" )
+TEST_CASE( "Rate of rotting", "[rot]" )
 {
     SECTION( "Passage of time" ) {
         // Item rot is a time duration.
@@ -72,7 +72,7 @@ TEST_CASE( "Rate of rotting" )
     }
 }
 
-TEST_CASE( "Items rot away" )
+TEST_CASE( "Items rot away", "[rot]" )
 {
     SECTION( "Item in reality bubble rots away" ) {
         // Item should rot away when it has 2x of its shelf life in rot.
@@ -94,4 +94,27 @@ TEST_CASE( "Items rot away" )
                 temperature_flag::HEATER ) );
         INFO( "Rot: " << to_turns<int>( test_item.get_rot() ) );
     }
+}
+
+TEST_CASE( "Hourly rotpoints", "[rot]" )
+{
+    item normal_item( "meat_cooked" );
+
+    // No rot below 32F/0C
+    CHECK( normal_item.get_hourly_rotpoints_at_temp( 30 ) == 0 );
+
+    // No rot above 145F/63C
+    CHECK( normal_item.get_hourly_rotpoints_at_temp( 150 ) == 0 );
+
+    // 3200 point/h at 65F/18C
+    CHECK( normal_item.get_hourly_rotpoints_at_temp( 65 ) == Approx( 3600 ).margin( 0.1 ) );
+
+    // Doubles after +16F
+    CHECK( normal_item.get_hourly_rotpoints_at_temp( 65 + 16 ) == Approx( 3600 * 2 ).margin( 0.1 ) );
+
+    // Test the linear area. Halfway between 32F/9C (0 point/hour) and 38F/3C (1117.672 point/hour)
+    CHECK( normal_item.get_hourly_rotpoints_at_temp( 35 ) == Approx( 1117.672 / 2 ).margin( 0.1 ) );
+
+    // Maximum rot at above 105 F
+    CHECK( normal_item.get_hourly_rotpoints_at_temp( 107 ) == Approx( 20364.6753 ).margin( 0.1 ) );
 }


### PR DESCRIPTION
#### Summary
Infrastructure "Refactor rotpoints"

#### Purpose of change

The way hourly rotpoints were calculated was odd.  
It rounded floats to ints unnecessarily.

#### Describe the solution

Just calculate the hourly rotpoints instead of looking up values from array.

Rot stops happening at temperatures above 145 F (63 C).

Moved `get_hourly_rotpoints_at_tempout` from `weather.h` to `item.h`.

Added some basic tests for `get_hourly_rotpoints_at_temp`.

#### Describe alternatives you've considered

In the old code a comment said that the rate of rotting should double every 10 C but in the code the rate of rotting doubled every 16 F (8.88 C).
I have left the code to double every 16 F but maybe it should be changed to 18 F (10 C).

#### Testing

Tests pass.
No noticeable performance difference.

#### Additional context
