### PR TITLE
Make all comestibles rot and have temperature

### DIFF
--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -576,7 +576,7 @@
     "bashing": 1,
     "phase": "liquid",
     "container": "bottle_glass",
-    "freezing_point": 25,
+    "freezing_point": -50,
     "drop_action": { "type": "emit_actor", "emits": [ "emit_acid_drop" ], "scale_qty": true }
   },
   {

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -542,7 +542,7 @@
     "count": 100
   },
   {
-    "type": "AMMO",
+    "type": "COMESTIBLE",
     "id": "chem_sulphuric_acid",
     "category": "chems",
     "price": 250,
@@ -555,14 +555,13 @@
     "volume": "250 ml",
     "weight": "460 g",
     "bashing": 1,
-    "ammo_type": "components",
     "phase": "liquid",
     "container": "bottle_glass",
-    "//freezing_point": 25,
+    "freezing_point": 25,
     "drop_action": { "type": "emit_actor", "emits": [ "emit_acid_drop" ], "scale_qty": true }
   },
   {
-    "type": "AMMO",
+    "type": "COMESTIBLE",
     "id": "chem_muriatic_acid",
     "category": "chems",
     "price": 250,
@@ -575,10 +574,9 @@
     "volume": "250 ml",
     "weight": "460 g",
     "bashing": 1,
-    "ammo_type": "components",
     "phase": "liquid",
     "container": "bottle_glass",
-    "//freezing_point": 25,
+    "freezing_point": 25,
     "drop_action": { "type": "emit_actor", "emits": [ "emit_acid_drop" ], "scale_qty": true }
   },
   {
@@ -599,7 +597,7 @@
     "container": "bottle_glass"
   },
   {
-    "type": "AMMO",
+    "type": "COMESTIBLE",
     "id": "chem_nitric_acid",
     "category": "chems",
     "price": 300,
@@ -612,10 +610,9 @@
     "volume": "250 ml",
     "weight": "375 g",
     "bashing": 1,
-    "ammo_type": "components",
     "phase": "liquid",
     "container": "bottle_glass",
-    "//freezing_point": -44,
+    "freezing_point": -44,
     "drop_action": { "type": "emit_actor", "emits": [ "emit_acid_drop" ], "scale_qty": true }
   },
   {

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -612,7 +612,7 @@
     "bashing": 1,
     "phase": "liquid",
     "container": "bottle_glass",
-    "freezing_point": -44,
+    "freezing_point": -42,
     "drop_action": { "type": "emit_actor", "emits": [ "emit_acid_drop" ], "scale_qty": true }
   },
   {

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -557,7 +557,7 @@
     "bashing": 1,
     "phase": "liquid",
     "container": "bottle_glass",
-    "freezing_point": 25,
+    "freezing_point": -36,
     "drop_action": { "type": "emit_actor", "emits": [ "emit_acid_drop" ], "scale_qty": true }
   },
   {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6852,11 +6852,6 @@ bool item::reinforceable() const
     } );
 }
 
-bool item::destroyed_at_zero_charges() const
-{
-    return ( is_ammo() || is_food() );
-}
-
 bool item::is_gun() const
 {
     return !!type->gun;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6854,7 +6854,7 @@ bool item::reinforceable() const
 
 bool item::destroyed_at_zero_charges() const
 {
-    return ( is_ammo() || is_comestible() );
+    return ( is_ammo() || is_food() );
 }
 
 bool item::is_gun() const
@@ -10422,7 +10422,7 @@ bool item::process_internal( player *carrier, const tripoint &pos,
     // Remaining stuff is only done for active items.
     if( active ) {
 
-        if( !is_comestible() && item_counter > 0 ) {
+        if( !is_food() && item_counter > 0 ) {
             item_counter--;
         }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -377,7 +377,7 @@ item::item( const recipe *rec, int qty, std::list<item> items, std::vector<item_
     components = items;
     craft_data_->comps_used = selections;
 
-    if( is_comestible() ) {
+    if( has_temperature() ) {
         active = true;
         last_temp_check = bday;
         if( goes_bad() ) {
@@ -411,7 +411,7 @@ item::item( const recipe *rec, item &component )
     std::list<item>items( { component } );
     components = items;
 
-    if( is_comestible() ) {
+    if( has_temperature() ) {
         active = true;
         last_temp_check = bday;
         if( goes_bad() ) {
@@ -4435,7 +4435,7 @@ nc_color item::color_in_inventory() const
         }
     } else if( has_flag( flag_LEAK_DAM ) && has_flag( flag_RADIOACTIVE ) && damage() > 0 ) {
         ret = c_light_green;
-    } else if( active && !is_comestible() &&  !is_corpse() ) {
+    } else if( active && !has_temperature() &&  !is_corpse() ) {
         // Active items show up as yellow
         ret = c_yellow;
     } else if( is_corpse() && can_revive() ) {
@@ -4974,7 +4974,7 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
         tagtext += _( " (lit)" );
     } else if( has_flag( flag_IS_UPS ) && get_var( "cable" ) == "plugged_in" ) {
         tagtext += _( " (plugged in)" );
-    } else if( active && !is_comestible() && !is_corpse() &&
+    } else if( active && !has_temperature() && !is_corpse() &&
                !string_ends_with( typeId().str(), "_on" ) ) {
         // Usually the items whose ids end in "_on" have the "active" or "on" string already contained
         // in their name, also food is active while it rots.
@@ -9417,7 +9417,7 @@ bool item::has_rotten_away() const
     if( is_corpse() && !can_revive() ) {
         return get_rot() > 10_days;
     } else {
-        return is_comestible() && get_relative_rot() > 2.0;
+        return get_relative_rot() > 2.0;
     }
 }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -308,7 +308,7 @@ item::item( const itype *type, time_point turn, int qty ) : type( type ), bday( 
                     item_pocket::pocket_type::MAGAZINE );
         }
 
-    } else if( has_temperature() || goes_bad() ) {
+    } else if( has_temperature() ) {
         active = true;
         last_temp_check = bday;
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9526,7 +9526,8 @@ bool item::needs_processing() const
 {
     bool need_process = false;
     visit_items( [&need_process]( const item * it, item * ) {
-        if( it->active || it->ethereal || it->has_flag( flag_RADIO_ACTIVATION ) || it->has_relic_recharge() ) {
+        if( it->active || it->ethereal || it->has_flag( flag_RADIO_ACTIVATION ) ||
+            it->has_relic_recharge() ) {
             need_process = true;
             return VisitResponse::ABORT;
         }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -377,7 +377,7 @@ item::item( const recipe *rec, int qty, std::list<item> items, std::vector<item_
     components = items;
     craft_data_->comps_used = selections;
 
-    if( is_food() ) {
+    if( is_comestible() ) {
         active = true;
         last_temp_check = bday;
         if( goes_bad() ) {
@@ -411,7 +411,7 @@ item::item( const recipe *rec, item &component )
     std::list<item>items( { component } );
     components = items;
 
-    if( is_food() ) {
+    if( is_comestible() ) {
         active = true;
         last_temp_check = bday;
         if( goes_bad() ) {
@@ -4435,7 +4435,7 @@ nc_color item::color_in_inventory() const
         }
     } else if( has_flag( flag_LEAK_DAM ) && has_flag( flag_RADIOACTIVE ) && damage() > 0 ) {
         ret = c_light_green;
-    } else if( active && !is_food() &&  !is_corpse() ) {
+    } else if( active && !is_comestible() &&  !is_corpse() ) {
         // Active items show up as yellow
         ret = c_yellow;
     } else if( is_corpse() && can_revive() ) {
@@ -4974,7 +4974,7 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
         tagtext += _( " (lit)" );
     } else if( has_flag( flag_IS_UPS ) && get_var( "cable" ) == "plugged_in" ) {
         tagtext += _( " (plugged in)" );
-    } else if( active && !is_food() && !is_corpse() &&
+    } else if( active && !is_comestible() && !is_corpse() &&
                !string_ends_with( typeId().str(), "_on" ) ) {
         // Usually the items whose ids end in "_on" have the "active" or "on" string already contained
         // in their name, also food is active while it rots.
@@ -5830,13 +5830,13 @@ bool item::goes_bad() const
         // Corpses rot only if they are made of rotting materials
         return made_of_any( materials::get_rotting() );
     }
-    return is_food() && get_comestible()->spoils != 0_turns;
+    return is_comestible() && get_comestible()->spoils != 0_turns;
 }
 
 time_duration item::get_shelf_life() const
 {
     if( goes_bad() ) {
-        if( is_food() ) {
+        if( is_comestible() ) {
             return get_comestible()->spoils;
         } else if( is_corpse() ) {
             return 24_hours;
@@ -6854,7 +6854,7 @@ bool item::reinforceable() const
 
 bool item::destroyed_at_zero_charges() const
 {
-    return ( is_ammo() || is_food() );
+    return ( is_ammo() || is_comestible() );
 }
 
 bool item::is_gun() const
@@ -7033,7 +7033,7 @@ bool item::is_food_container() const
 
 bool item::has_temperature() const
 {
-    return is_food() || is_corpse();
+    return is_comestible() || is_corpse();
 }
 
 bool item::is_corpse() const
@@ -9417,7 +9417,7 @@ bool item::has_rotten_away() const
     if( is_corpse() && !can_revive() ) {
         return get_rot() > 10_days;
     } else {
-        return is_food() && get_relative_rot() > 2.0;
+        return is_comestible() && get_relative_rot() > 2.0;
     }
 }
 
@@ -9526,8 +9526,7 @@ bool item::needs_processing() const
 {
     bool need_process = false;
     visit_items( [&need_process]( const item * it, item * ) {
-        if( it->active || it->ethereal || it->has_flag( flag_RADIO_ACTIVATION ) ||
-            it->is_food() || it->has_relic_recharge() ) {
+        if( it->active || it->ethereal || it->has_flag( flag_RADIO_ACTIVATION ) || it->has_relic_recharge() ) {
             need_process = true;
             return VisitResponse::ABORT;
         }
@@ -9538,7 +9537,7 @@ bool item::needs_processing() const
 
 int item::processing_speed() const
 {
-    if( is_corpse() || is_food() ) {
+    if( is_corpse() || is_comestible() ) {
         return to_turns<int>( 10_minutes );
     }
     // Unless otherwise indicated, update every turn.
@@ -10422,7 +10421,7 @@ bool item::process_internal( player *carrier, const tripoint &pos,
     // Remaining stuff is only done for active items.
     if( active ) {
 
-        if( !is_food() && item_counter > 0 ) {
+        if( !is_comestible() && item_counter > 0 ) {
             item_counter--;
         }
 

--- a/src/item.h
+++ b/src/item.h
@@ -1198,7 +1198,6 @@ class item : public visitable
 
         void overwrite_relic( const relic &nrelic );
 
-        bool destroyed_at_zero_charges() const;
         // Most of the is_whatever() functions call the same function in our itype
         bool is_null() const; // True if type is NULL, or points to the null item (id == 0)
         bool is_comestible() const;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4759,8 +4759,7 @@ cata::optional<int> iuse::blood_draw( player *p, item *it, bool, const tripoint 
 
     if( acid_blood ) {
         item acid( "chem_sulphuric_acid", calendar::turn );
-        // Acid should have temperature. But it currently does not. So trying to set it crashes the game.
-        // When acid gets temperature just add acid.set_item_temperature( blood_temp ); here
+        acid.set_item_temperature( blood_temp );
         it->put_in( acid, item_pocket::pocket_type::CONTAINER );
         if( one_in( 3 ) ) {
             if( it->inc_damage( damage_type::ACID ) ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4460,7 +4460,7 @@ item &map::add_item( const tripoint &p, item new_item )
 
     // Process foods and temperature tracked items when they are added to the map, here instead of add_item_at()
     // to avoid double processing food and corpses during active item processing.
-    if( new_item.is_food() || new_item.has_temperature() ) {
+    if( new_item.has_temperature() ) {
         new_item.process( nullptr, p );
     }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1096,7 +1096,7 @@ void player::siphon( vehicle &veh, const itype_id &desired_liquid )
     }
 
     item liquid( desired_liquid, calendar::turn, qty );
-    if( liquid.is_food() ) {
+    if( liquid.has_temperature() ) {
         liquid.set_item_specific_energy( veh.fuel_specific_energy( desired_liquid ) );
     }
     if( liquid_handler::handle_liquid( liquid, nullptr, 1, nullptr, &veh ) ) {

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -890,7 +890,7 @@ std::function<bool( const item & )> recipe::get_component_filter(
     // EDIBLE_FROZEN components ( e.g. flour, chocolate ) are allowed as well
     // Otherwise forbid them
     std::function<bool( const item & )> frozen_filter = return_true<item>;
-    if( result.is_food() && !hot_result() ) {
+    if( result.has_temperature() && !hot_result() ) {
         frozen_filter = []( const item & component ) {
             return !component.has_flag( flag_FROZEN ) || component.has_flag( flag_EDIBLE_FROZEN );
         };
@@ -1029,7 +1029,7 @@ bool recipe::hot_result() const
     // the check includes this tool in addition to the hotplate.
     //
     // TODO: Make this less of a hack
-    if( create_result().is_food() ) {
+    if( create_result().has_temperature() ) {
         const requirement_data::alter_tool_comp_vector &tool_lists = simple_requirements().get_tools();
         for( const std::vector<tool_comp> &tools : tool_lists ) {
             for( const tool_comp &t : tools ) {

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2548,7 +2548,9 @@ void item::io( Archive &archive )
     if( count_by_charges() && charges <= 0 ) {
         charges = item( type, calendar::turn_zero ).charges;
     }
-    if( has_temperature() || goes_bad() ) {
+
+    // Items from old saves before those items were temperature tracked need activating.
+    if( has_temperature() ) {
         active = true;
     }
     if( !active && ( has_own_flag( flag_HOT ) || has_own_flag( flag_COLD ) ||

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2548,7 +2548,7 @@ void item::io( Archive &archive )
     if( count_by_charges() && charges <= 0 ) {
         charges = item( type, calendar::turn_zero ).charges;
     }
-    if( is_food() ) {
+    if( has_temperature() || goes_bad() ) {
         active = true;
     }
     if( !active && ( has_own_flag( flag_HOT ) || has_own_flag( flag_COLD ) ||


### PR DESCRIPTION
#### Summary
Features "Make all comestibles rot and have temperature"

#### Purpose of change

Chemicals like acids do not have temperatures. They really should. 

#### Describe the solution

Change the type of the three acids from "AMMO" to "COMESTIBLE".

Acid extracted from acid zombie corpse has its temperature set.

"food" in code is just a comestible with comestible_type=food or comestible_type=drink defined for it.
Various things only applied to foods specifically. Changed them to apply to all "COMESTIBLE" in general:
* All comestibles now have temperature
* All comestibles can now rot (requires spoils data in the json for that item)
* Various  is_food() checks were generalized into has_temperature() checks. Rot does not need separate check because all items that rot also have temperature.

The is_food() check in needs_processing() was unnecessary. Foods need processing because they have temperatures but items with temperature are already active.

destroyed_at_zero_charges() was not used anywhere. Removed it.

#### Describe alternatives you've considered

Make acid into drink.

Give all items temperature. Or sby default everything has temperature but certain things do not have temperature. Potential performance problems.

#### Testing


#### Additional context

You can now have frozen manure. And with trivial JSON change you can also make manure rot. Make what you wish with that information.

All the chemicals should probably be changed from ammo into comestibles. Just look at how `fungicide` is done for the ones that are counted by charges.
If that is done then some of the chemicals will need material data for them. Without that they default to thermal properties of water (including freezing at 0C).