### PR TITLE
stop passing container variables

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10267,11 +10267,11 @@ void Character::process_items()
     }
 
     std::vector<item_location> removed_items;
-    for( item_location it : top_items_loc() ) {
+    for( item_location it : all_items_loc() ) {
         if( !it ) {
             continue;
         }
-        if( it->needs_processing() ) {
+        if( it->needs_processing() && it.get_item() != &weapon ) {
             if( it->process( this, pos() ) ) {
                 it->spill_contents( pos() );
                 removed_items.push_back( it );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5199,7 +5199,7 @@ static void mill_activate( Character &you, const tripoint &examp )
     for( item &it : here.i_at( examp ) ) {
         if( it.type->milling_data ) {
             // Do one final rot check before milling, then apply the PROCESSING flag to prevent further checks.
-            it.process_temperature_rot( 1, examp, nullptr );
+            it.process_temperature_rot( examp, nullptr );
             it.set_flag( flag_PROCESSING );
         }
     }
@@ -5300,7 +5300,7 @@ static void smoker_activate( Character &you, const tripoint &examp )
     you.use_charges( itype_fire, 1 );
     for( item &it : here.i_at( examp ) ) {
         if( it.has_flag( flag_SMOKABLE ) ) {
-            it.process_temperature_rot( 1, examp, nullptr );
+            it.process_temperature_rot( examp, nullptr );
             it.set_flag( flag_PROCESSING );
         }
     }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9847,16 +9847,7 @@ uint64_t item::make_component_hash() const
 
 bool item::needs_processing() const
 {
-    bool need_process = false;
-    visit_items( [&need_process]( const item * it, item * ) {
-        if( it->active || it->ethereal || it->wetness || it->has_flag( flag_RADIO_ACTIVATION ) ||
-            it->has_relic_recharge() ) {
-            need_process = true;
-            return VisitResponse::ABORT;
-        }
-        return VisitResponse::NEXT;
-    } );
-    return need_process;
+    return active || ethereal || wetness || has_flag( flag_RADIO_ACTIVATION ) || has_relic_recharge();
 }
 
 int item::processing_speed() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7294,9 +7294,9 @@ float item::get_freeze_point() const
     return made_of_types()[0]->freeze_point();
 }
 
-float get_spoil_modifier()
+float item::get_spoil_modifier() const
 {
-    return 1;
+    return 1.f;
     // item parent =
     // if( parent ) {
     //spoil multipliers on pockets are not additive or multiplicative, they choose the best
@@ -7305,9 +7305,9 @@ float get_spoil_modifier()
     // return spoil_multiplier();
 }
 
-float get_thermal_insulation()
+float item::get_thermal_insulation() const
 {
-    return 1;
+    return 1.f;
     // item parent =
     // if( parent ) {
     // return type.insulation_factor * parent.get_thermal_insulation();
@@ -9895,12 +9895,8 @@ bool item::process_temperature_rot( const tripoint &pos,
         return false;
     }
 
-    float insulation = 1.f;
-    float spoil_modifier = 1.f;
-    // if( parent ) {
-    // insulation = parent.get_thermal_insulation();
-    // spoil_modifier = parent.get_spoil_modifier();
-    // }
+    float insulation = get_thermal_insulation();
+    float spoil_modifier = get_spoil_modifier();
 
     int temp = get_weather().get_temperature( pos );
 

--- a/src/item.h
+++ b/src/item.h
@@ -890,14 +890,13 @@ class item : public visitable
          * Update temperature for things like food
          * Update rot for things that perish
          * All items that rot also have temperature
-         * @param insulation Amount of insulation item has from surroundings
          * @param pos The current position
          * @param carrier The current carrier
          * @param flag to specify special temperature situations
          * @return true if the item is fully rotten and is ready to be removed
          */
-        bool process_temperature_rot( float insulation, const tripoint &pos, Character *carrier,
-                                      temperature_flag flag = temperature_flag::NORMAL, float spoil_modifier = 1.0f );
+        bool process_temperature_rot( const tripoint &pos, Character *carrier,
+                                      temperature_flag flag = temperature_flag::NORMAL );
 
         /** Set the item to HOT and resets last_temp_check */
         void heat_up();
@@ -1201,15 +1200,12 @@ class item : public visitable
          * @param pos The location of the item on the map, same system as
          * @ref player::pos used. If the item is carried, it should be the
          * location of the carrier.
-         * @param activate Whether the item should be activated (true), or
-         * processed as an active item.
-         * @param spoil_multiplier_parent is the spoilage multiplier passed down from any parent item
          * @return true if the item has been destroyed by the processing. The caller
          * should than delete the item wherever it was stored.
          * Returns false if the item is not destroyed.
          */
-        bool process( Character *carrier, const tripoint &pos, float insulation = 1,
-                      temperature_flag flag = temperature_flag::NORMAL, float spoil_multiplier_parent = 1.0f );
+        bool process( Character *carrier, const tripoint &pos,
+                      temperature_flag flag = temperature_flag::NORMAL );
 
         /**
          * Gets the point (vehicle tile) the cable is connected to.
@@ -1293,6 +1289,9 @@ class item : public visitable
         float get_specific_heat_solid() const;
         float get_latent_heat() const;
         float get_freeze_point() const; // Celsius
+
+        float get_spoil_modifier();
+        float get_thermal_insulation();
 
         // If this is food, returns itself.  If it contains food, return that
         // contents.  Otherwise, returns nullptr.
@@ -2378,8 +2377,8 @@ class item : public visitable
         bool use_amount_internal( const itype_id &it, int &quantity, std::list<item> &used,
                                   const std::function<bool( const item & )> &filter = return_true<item> );
         const use_function *get_use_internal( const std::string &use_name ) const;
-        bool process_internal( Character *carrier, const tripoint &pos, float insulation = 1,
-                               temperature_flag flag = temperature_flag::NORMAL, float spoil_modifier = 1.0f );
+        bool process_internal( Character *carrier, const tripoint &pos,
+                               temperature_flag flag = temperature_flag::NORMAL );
         void iterate_covered_body_parts_internal( side s,
                 std::function<void( const bodypart_str_id & )> cb ) const;
         /**

--- a/src/item.h
+++ b/src/item.h
@@ -1290,8 +1290,8 @@ class item : public visitable
         float get_latent_heat() const;
         float get_freeze_point() const; // Celsius
 
-        float get_spoil_modifier();
-        float get_thermal_insulation();
+        float get_spoil_modifier() const;
+        float get_thermal_insulation() const;
 
         // If this is food, returns itself.  If it contains food, return that
         // contents.  Otherwise, returns nullptr.

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1479,13 +1479,13 @@ void item_contents::remove_internal( const std::function<bool( item & )> &filter
     }
 }
 
-void item_contents::process( Character *carrier, const tripoint &pos, float insulation,
-                             temperature_flag flag, float spoil_multiplier_parent )
+void item_contents::process( Character *carrier, const tripoint &pos,
+                             temperature_flag flag )
 {
     for( item_pocket &pocket : contents ) {
         // no reason to check mods, they won't rot
         if( !pocket.is_type( item_pocket::pocket_type::MOD ) ) {
-            pocket.process( carrier, pos, insulation, flag, spoil_multiplier_parent );
+            pocket.process( carrier, pos, flag );
         }
     }
 }

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -246,8 +246,8 @@ class item_contents
          * Is part of the recursive call of item::process. see that function for additional comments
          * NOTE: this destroys the items that get processed
          */
-        void process( Character *carrier, const tripoint &pos, float insulation = 1,
-                      temperature_flag flag = temperature_flag::NORMAL, float spoil_multiplier_parent = 1.0f );
+        void process( Character *carrier, const tripoint &pos,
+                      temperature_flag flag = temperature_flag::NORMAL );
 
         bool item_has_uses_recursive() const;
         bool stacks_with( const item_contents &rhs ) const;

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -768,15 +768,11 @@ bool item_pocket::detonate( const tripoint &pos, std::vector<item> &drops )
 }
 
 bool item_pocket::process( const itype &type, Character *carrier, const tripoint &pos,
-                           float insulation, const temperature_flag flag )
+                           const temperature_flag flag )
 {
     bool processed = false;
-    float spoil_multiplier = 1.0f;
     for( auto it = contents.begin(); it != contents.end(); ) {
-        if( _sealed ) {
-            spoil_multiplier = 0.0f;
-        }
-        if( it->process( carrier, pos, type.insulation_factor * insulation, flag, spoil_multiplier ) ) {
+        if( it->process( carrier, pos, flag ) ) {
             it->spill_contents( pos );
             it = contents.erase( it );
             processed = true;
@@ -1352,13 +1348,11 @@ void item_pocket::remove_items_if( const std::function<bool( item & )> &filter )
     on_contents_changed();
 }
 
-void item_pocket::process( Character *carrier, const tripoint &pos, float insulation,
-                           temperature_flag flag, float spoil_multiplier_parent )
+void item_pocket::process( Character *carrier, const tripoint &pos,
+                           temperature_flag flag )
 {
     for( auto iter = contents.begin(); iter != contents.end(); ) {
-        if( iter->process( carrier, pos, insulation, flag,
-                           // spoil multipliers on pockets are not additive or multiplicative, they choose the best
-                           std::min( spoil_multiplier_parent, spoil_multiplier() ) ) ) {
+        if( iter->process( carrier, pos, flag ) ) {
             iter->spill_contents( pos );
             iter = contents.erase( iter );
         } else {

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -238,8 +238,7 @@ class item_pocket
 
         std::string translated_sealed_prefix() const;
         bool detonate( const tripoint &p, std::vector<item> &drops );
-        bool process( const itype &type, Character *carrier, const tripoint &pos,
-                      float insulation, temperature_flag flag );
+        bool process( const itype &type, Character *carrier, const tripoint &pos, temperature_flag flag );
         void remove_all_ammo( Character &guy );
         void remove_all_mods( Character &guy );
 
@@ -262,8 +261,8 @@ class item_pocket
          * Is part of the recursive call of item::process. see that function for additional comments
          * NOTE: this destroys the items that get processed
          */
-        void process( Character *carrier, const tripoint &pos, float insulation = 1,
-                      temperature_flag flag = temperature_flag::NORMAL, float spoil_multiplier_parent = 1.0f );
+        void process( Character *carrier, const tripoint &pos,
+                      temperature_flag flag = temperature_flag::NORMAL );
         pocket_type saved_type() const {
             return _saved_type;
         }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4529,7 +4529,7 @@ static bool process_map_items( item_stack &items, safe_reference<item> &item_ref
                                const float spoil_multiplier )
 {
     if( item_ref->process( nullptr, location, flag ) ) {
-		// TODO: FIX INSULATION FROM MAP SOURCES
+        // TODO: FIX INSULATION FROM MAP SOURCES
         // Item is to be destroyed so erase it from the map stack
         // unless it was already destroyed by processing.
         if( item_ref ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4525,9 +4525,11 @@ void map::update_lum( item_location &loc, bool add )
 }
 
 static bool process_map_items( item_stack &items, safe_reference<item> &item_ref,
-                               const tripoint &location, const temperature_flag flag )
+                               const tripoint &location, const float insulation, const temperature_flag flag,
+                               const float spoil_multiplier )
 {
     if( item_ref->process( nullptr, location, flag ) ) {
+		// TODO: FIX INSULATION FROM MAP SOURCES
         // Item is to be destroyed so erase it from the map stack
         // unless it was already destroyed by processing.
         if( item_ref ) {
@@ -4728,7 +4730,7 @@ void map::process_items_in_submap( submap &current_submap, const tripoint &gridp
 
         map_stack items = i_at( map_location );
 
-        process_map_items( items, active_item_ref.item_ref, map_location, flag );
+        process_map_items( items, active_item_ref.item_ref, map_location, 1, flag, spoil_multiplier );
     }
 }
 
@@ -4803,7 +4805,7 @@ void map::process_items_in_vehicle( vehicle &cur_veh, submap &current_submap )
                 flag = temperature_flag::FREEZER;
             }
         }
-        if( !process_map_items( items, active_item_ref.item_ref, item_loc, flag ) ) {
+        if( !process_map_items( items, active_item_ref.item_ref, item_loc, it_insulation, flag, 1.0f ) ) {
             // If the item was NOT destroyed, we can skip the remainder,
             // which handles fallout from the vehicle being damaged.
             continue;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4525,10 +4525,9 @@ void map::update_lum( item_location &loc, bool add )
 }
 
 static bool process_map_items( item_stack &items, safe_reference<item> &item_ref,
-                               const tripoint &location, const float insulation, const temperature_flag flag,
-                               const float spoil_multiplier )
+                               const tripoint &location, const temperature_flag flag )
 {
-    if( item_ref->process( nullptr, location, insulation, flag, spoil_multiplier ) ) {
+    if( item_ref->process( nullptr, location, flag ) ) {
         // Item is to be destroyed so erase it from the map stack
         // unless it was already destroyed by processing.
         if( item_ref ) {
@@ -4729,7 +4728,7 @@ void map::process_items_in_submap( submap &current_submap, const tripoint &gridp
 
         map_stack items = i_at( map_location );
 
-        process_map_items( items, active_item_ref.item_ref, map_location, 1, flag, spoil_multiplier );
+        process_map_items( items, active_item_ref.item_ref, map_location, flag );
     }
 }
 
@@ -4804,7 +4803,7 @@ void map::process_items_in_vehicle( vehicle &cur_veh, submap &current_submap )
                 flag = temperature_flag::FREEZER;
             }
         }
-        if( !process_map_items( items, active_item_ref.item_ref, item_loc, it_insulation, flag, 1.0f ) ) {
+        if( !process_map_items( items, active_item_ref.item_ref, item_loc, flag ) ) {
             // If the item was NOT destroyed, we can skip the remainder,
             // which handles fallout from the vehicle being damaged.
             continue;

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -414,7 +414,7 @@ void vehicle_part::process_contents( const tripoint &pos, const bool e_heater )
         } else if( enabled && info().has_flag( VPFLAG_FREEZER ) ) {
             flag = temperature_flag::FREEZER;
         }
-        base.process( nullptr, pos, 1, flag );
+        base.process( nullptr, pos, flag );
     }
 }
 

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -36,9 +36,9 @@ TEST_CASE( "Rate of rotting", "[rot]" )
 
         set_map_temperature( 65 ); // 18,3 C
 
-        normal_item.process( nullptr, tripoint_zero, 1, temperature_flag::NORMAL );
-        sealed_item.process( nullptr, tripoint_zero, 1, temperature_flag::NORMAL );
-        freeze_item.process( nullptr, tripoint_zero, 1, temperature_flag::NORMAL );
+        normal_item.process( nullptr, tripoint_zero, temperature_flag::NORMAL );
+        sealed_item.process( nullptr, tripoint_zero, temperature_flag::NORMAL );
+        freeze_item.process( nullptr, tripoint_zero, temperature_flag::NORMAL );
 
         // Item should exist with no rot when it is brand new
         CHECK( normal_item.get_rot() == 0_turns );
@@ -48,9 +48,9 @@ TEST_CASE( "Rate of rotting", "[rot]" )
         INFO( "Initial turn: " << to_turn<int>( calendar::turn ) );
 
         calendar::turn += 20_minutes;
-        normal_item.process( nullptr, tripoint_zero, 1, temperature_flag::NORMAL );
-        sealed_item.process( nullptr, tripoint_zero, 1, temperature_flag::NORMAL );
-        freeze_item.process( nullptr, tripoint_zero, 1, temperature_flag::FREEZER );
+        normal_item.process( nullptr, tripoint_zero, temperature_flag::NORMAL );
+        sealed_item.process( nullptr, tripoint_zero, temperature_flag::NORMAL );
+        freeze_item.process( nullptr, tripoint_zero, temperature_flag::FREEZER );
 
         // After 20 minutes the normal item should have 20 minutes of rot
         CHECK( to_turns<int>( normal_item.get_rot() )
@@ -61,8 +61,8 @@ TEST_CASE( "Rate of rotting", "[rot]" )
 
         // Move time 110 minutes
         calendar::turn += 110_minutes;
-        sealed_item.process( nullptr, tripoint_zero, 1, temperature_flag::NORMAL );
-        freeze_item.process( nullptr, tripoint_zero, 1, temperature_flag::FREEZER );
+        sealed_item.process( nullptr, tripoint_zero, temperature_flag::NORMAL );
+        freeze_item.process( nullptr, tripoint_zero, temperature_flag::FREEZER );
         // In freezer and in preserving container still should be no rot
         CHECK( sealed_item.get_rot() == 0_turns );
         CHECK( freeze_item.get_rot() == 0_turns );
@@ -84,13 +84,13 @@ TEST_CASE( "Items rot away", "[rot]" )
         item test_item( "meat_cooked" );
 
         // Process item once to set all of its values.
-        test_item.process( nullptr, tripoint_zero, 1, temperature_flag::HEATER );
+        test_item.process( nullptr, tripoint_zero, temperature_flag::HEATER );
 
         // Set rot to >2 days and process again. process_temperature_rot should return true.
         calendar::turn += 20_minutes;
         test_item.mod_rot( 2_days );
 
-        CHECK( test_item.process_temperature_rot( 1, tripoint_zero, nullptr,
+        CHECK( test_item.process_temperature_rot( tripoint_zero, nullptr,
                 temperature_flag::HEATER ) );
         INFO( "Rot: " << to_turns<int>( test_item.get_rot() ) );
     }

--- a/tests/temperature_test.cpp
+++ b/tests/temperature_test.cpp
@@ -26,7 +26,7 @@ TEST_CASE( "Item spawns with right thermal attributes" )
     CHECK( D.specific_energy == -10 );
 
     set_map_temperature( 122 );
-    D.process_temperature_rot( 1, tripoint_zero, nullptr );
+    D.process_temperature_rot( tripoint_zero, nullptr );
 
     CHECK( D.temperature == Approx( 323.15 * 100000 ).margin( 1 ) );
 }
@@ -62,8 +62,8 @@ TEST_CASE( "Rate of temperature change" )
 
         set_map_temperature( 131 ); // 55 C
 
-        water1.process_temperature_rot( 1, tripoint_zero, nullptr );
-        water2.process_temperature_rot( 1, tripoint_zero, nullptr );
+        water1.process_temperature_rot( tripoint_zero, nullptr );
+        water2.process_temperature_rot( tripoint_zero, nullptr );
 
         // 55 C
         CHECK( water1.temperature == Approx( 328.15 * 100000 ).margin( 1 ) );
@@ -71,18 +71,18 @@ TEST_CASE( "Rate of temperature change" )
         set_map_temperature( 68 ); // 20C
 
         calendar::turn += 11_minutes;
-        water1.process_temperature_rot( 1, tripoint_zero, nullptr );
+        water1.process_temperature_rot( tripoint_zero, nullptr );
 
         calendar::turn += 20_minutes;
-        water1.process_temperature_rot( 1, tripoint_zero, nullptr );
+        water1.process_temperature_rot( tripoint_zero, nullptr );
 
         calendar::turn += 29_minutes;
-        water1.process_temperature_rot( 1, tripoint_zero, nullptr );
-        water2.process_temperature_rot( 1, tripoint_zero, nullptr );
+        water1.process_temperature_rot( tripoint_zero, nullptr );
+        water2.process_temperature_rot( tripoint_zero, nullptr );
 
         calendar::turn += 15_minutes;
-        water1.process_temperature_rot( 1, tripoint_zero, nullptr );
-        water2.process_temperature_rot( 1, tripoint_zero, nullptr );
+        water1.process_temperature_rot( tripoint_zero, nullptr );
+        water2.process_temperature_rot( tripoint_zero, nullptr );
 
         // about 29.6 C
         CHECK( water1.temperature == Approx( 30271802 ).margin( 1 ) );
@@ -102,8 +102,8 @@ TEST_CASE( "Rate of temperature change" )
 
         set_map_temperature( 122 ); //50 C
 
-        meat1.process_temperature_rot( 1, tripoint_zero, nullptr );
-        meat2.process_temperature_rot( 1, tripoint_zero, nullptr );
+        meat1.process_temperature_rot( tripoint_zero, nullptr );
+        meat2.process_temperature_rot( tripoint_zero, nullptr );
 
         // 50 C
         CHECK( meat1.temperature == Approx( 323.15 * 100000 ).margin( 1 ) );
@@ -112,24 +112,24 @@ TEST_CASE( "Rate of temperature change" )
         set_map_temperature( -4 ); // -20 C
 
         calendar::turn += 15_minutes;
-        meat1.process_temperature_rot( 1, tripoint_zero, nullptr );
-        meat2.process_temperature_rot( 1, tripoint_zero, nullptr );
+        meat1.process_temperature_rot( tripoint_zero, nullptr );
+        meat2.process_temperature_rot( tripoint_zero, nullptr );
 
         // about 34.6 C
         CHECK( meat1.temperature == Approx( 30778338 ).margin( 1 ) );
         CHECK( !meat1.has_own_flag( flag_HOT ) );
 
         calendar::turn += 11_minutes;
-        meat1.process_temperature_rot( 1, tripoint_zero, nullptr );
+        meat1.process_temperature_rot( tripoint_zero, nullptr );
         calendar::turn += 11_minutes;
-        meat1.process_temperature_rot( 1, tripoint_zero, nullptr );
+        meat1.process_temperature_rot( tripoint_zero, nullptr );
 
         calendar::turn += 30_minutes;
-        meat1.process_temperature_rot( 1, tripoint_zero, nullptr );
-        meat2.process_temperature_rot( 1, tripoint_zero, nullptr );
+        meat1.process_temperature_rot( tripoint_zero, nullptr );
+        meat2.process_temperature_rot( tripoint_zero, nullptr );
         calendar::turn += 11_minutes;
-        meat1.process_temperature_rot( 1, tripoint_zero, nullptr );
-        meat2.process_temperature_rot( 1, tripoint_zero, nullptr );
+        meat1.process_temperature_rot( tripoint_zero, nullptr );
+        meat2.process_temperature_rot( tripoint_zero, nullptr );
 
         // 0C
         // not frozen
@@ -139,11 +139,11 @@ TEST_CASE( "Rate of temperature change" )
         CHECK( !meat2.has_own_flag( flag_FROZEN ) );
 
         calendar::turn += 60_minutes;
-        meat1.process_temperature_rot( 1, tripoint_zero, nullptr );
-        meat2.process_temperature_rot( 1, tripoint_zero, nullptr );
+        meat1.process_temperature_rot( tripoint_zero, nullptr );
+        meat2.process_temperature_rot( tripoint_zero, nullptr );
         calendar::turn += 60_minutes;
-        meat1.process_temperature_rot( 1, tripoint_zero, nullptr );
-        meat2.process_temperature_rot( 1, tripoint_zero, nullptr );
+        meat1.process_temperature_rot( tripoint_zero, nullptr );
+        meat2.process_temperature_rot( tripoint_zero, nullptr );
 
         // 0C
         // frozen
@@ -154,16 +154,16 @@ TEST_CASE( "Rate of temperature change" )
         CHECK( meat1.specific_energy == Approx( meat2.specific_energy ).margin( 1 ) );
 
         calendar::turn += 11_minutes;
-        meat1.process_temperature_rot( 1, tripoint_zero, nullptr );
+        meat1.process_temperature_rot( tripoint_zero, nullptr );
         calendar::turn += 20_minutes;
-        meat1.process_temperature_rot( 1, tripoint_zero, nullptr );
+        meat1.process_temperature_rot( tripoint_zero, nullptr );
 
         calendar::turn += 20_minutes;
-        meat1.process_temperature_rot( 1, tripoint_zero, nullptr );
-        meat2.process_temperature_rot( 1, tripoint_zero, nullptr );
+        meat1.process_temperature_rot( tripoint_zero, nullptr );
+        meat2.process_temperature_rot( tripoint_zero, nullptr );
         calendar::turn += 50_minutes;
-        meat1.process_temperature_rot( 1, tripoint_zero, nullptr );
-        meat2.process_temperature_rot( 1, tripoint_zero, nullptr );
+        meat1.process_temperature_rot( tripoint_zero, nullptr );
+        meat2.process_temperature_rot( tripoint_zero, nullptr );
 
         // about -5.2 C
         // frozen
@@ -189,8 +189,8 @@ TEST_CASE( "Rate of temperature change" )
 
         set_map_temperature( -4 ); // -20 C
 
-        meat1.process_temperature_rot( 1, tripoint_zero, nullptr );
-        meat2.process_temperature_rot( 1, tripoint_zero, nullptr );
+        meat1.process_temperature_rot( tripoint_zero, nullptr );
+        meat2.process_temperature_rot( tripoint_zero, nullptr );
 
         // -20 C
         CHECK( meat1.temperature == Approx( 253.15 * 100000 ).margin( 1 ) );
@@ -199,19 +199,19 @@ TEST_CASE( "Rate of temperature change" )
         set_map_temperature( 68 ); // 20 C
 
         calendar::turn += 11_minutes;
-        meat1.process_temperature_rot( 1, tripoint_zero, nullptr );
+        meat1.process_temperature_rot( tripoint_zero, nullptr );
         // about -9.3 C
         CHECK( meat1.temperature == Approx( 26389390 ).margin( 1 ) );
 
         calendar::turn += 11_minutes;
-        meat1.process_temperature_rot( 1, tripoint_zero, nullptr );
+        meat1.process_temperature_rot( tripoint_zero, nullptr );
 
         calendar::turn += 11_minutes;
-        meat1.process_temperature_rot( 1, tripoint_zero, nullptr );
+        meat1.process_temperature_rot( tripoint_zero, nullptr );
 
         calendar::turn += 20_minutes;
-        meat1.process_temperature_rot( 1, tripoint_zero, nullptr );
-        meat2.process_temperature_rot( 1, tripoint_zero, nullptr );
+        meat1.process_temperature_rot( tripoint_zero, nullptr );
+        meat2.process_temperature_rot( tripoint_zero, nullptr );
 
         // 0C
         // same temp
@@ -222,12 +222,12 @@ TEST_CASE( "Rate of temperature change" )
         CHECK( meat2.has_own_flag( flag_FROZEN ) );
 
         calendar::turn += 45_minutes;
-        meat1.process_temperature_rot( 1, tripoint_zero, nullptr );
-        meat2.process_temperature_rot( 1, tripoint_zero, nullptr );
+        meat1.process_temperature_rot( tripoint_zero, nullptr );
+        meat2.process_temperature_rot( tripoint_zero, nullptr );
 
         calendar::turn += 45_minutes;
-        meat1.process_temperature_rot( 1, tripoint_zero, nullptr );
-        meat2.process_temperature_rot( 1, tripoint_zero, nullptr );
+        meat1.process_temperature_rot( tripoint_zero, nullptr );
+        meat2.process_temperature_rot( tripoint_zero, nullptr );
 
         // 0C
         // same temp
@@ -237,16 +237,16 @@ TEST_CASE( "Rate of temperature change" )
         CHECK( !meat1.has_own_flag( flag_FROZEN ) );
 
         calendar::turn += 11_minutes;
-        meat1.process_temperature_rot( 1, tripoint_zero, nullptr );
+        meat1.process_temperature_rot( tripoint_zero, nullptr );
         calendar::turn += 20_minutes;
-        meat1.process_temperature_rot( 1, tripoint_zero, nullptr );
+        meat1.process_temperature_rot( tripoint_zero, nullptr );
 
         calendar::turn += 20_minutes;
-        meat1.process_temperature_rot( 1, tripoint_zero, nullptr );
-        meat2.process_temperature_rot( 1, tripoint_zero, nullptr );
+        meat1.process_temperature_rot( tripoint_zero, nullptr );
+        meat2.process_temperature_rot( tripoint_zero, nullptr );
         calendar::turn += 50_minutes;
-        meat1.process_temperature_rot( 1, tripoint_zero, nullptr );
-        meat2.process_temperature_rot( 1, tripoint_zero, nullptr );
+        meat1.process_temperature_rot( tripoint_zero, nullptr );
+        meat2.process_temperature_rot( tripoint_zero, nullptr );
 
         // about 2.2 C
         CHECK( meat1.temperature == Approx( 27532468 ).margin( 1 ) );
@@ -265,21 +265,21 @@ TEST_CASE( "Temperature controlled location" )
 
         set_map_temperature( 0 ); // -17 C
 
-        water1.process_temperature_rot( 1, tripoint_zero, nullptr,
+        water1.process_temperature_rot( tripoint_zero, nullptr,
                                         temperature_flag::HEATER );
 
         CHECK( water1.temperature == Approx( 100000 * temp_to_kelvin( temperatures::normal ) ).margin(
                    1 ) );
 
         calendar::turn += 15_minutes;
-        water1.process_temperature_rot( 1, tripoint_zero, nullptr,
+        water1.process_temperature_rot( tripoint_zero, nullptr,
                                         temperature_flag::HEATER );
 
         CHECK( water1.temperature == Approx( 100000 * temp_to_kelvin( temperatures::normal ) ).margin(
                    1 ) );
 
         calendar::turn += 2_hours + 3_minutes;
-        water1.process_temperature_rot( 1, tripoint_zero, nullptr,
+        water1.process_temperature_rot( tripoint_zero, nullptr,
                                         temperature_flag::HEATER );
 
         CHECK( water1.temperature == Approx( 100000 * temp_to_kelvin( temperatures::normal ) ).margin(


### PR DESCRIPTION


#### Summary
Infrastructure "Don't process containers of active items"

#### Purpose of change

Processing containers of active items causes all of the contents being processed as active items.

#### Describe the solution

Only  process active items directly.
Get container attributes during this processing.

#### Describe alternatives you've considered



#### Testing


#### Additional context

