### PR TITLE
Adjust time approximations

### DIFF
--- a/src/calendar.cpp
+++ b/src/calendar.cpp
@@ -333,7 +333,7 @@ time_point daylight_time( const time_point &p )
 
 bool is_night( const time_point &p )
 {
-    return sun_altitude( p ) <= nautical_dawn;
+    return sun_altitude( p ) <= civil_dawn;
 }
 
 bool is_day( const time_point &p )
@@ -344,7 +344,7 @@ bool is_day( const time_point &p )
 static bool is_twilight( const time_point &p )
 {
     units::angle altitude = sun_altitude( p );
-    return altitude >= astronomical_dawn && altitude <= sunrise_angle;
+    return altitude >= civil_dawn && altitude <= sunrise_angle;
 }
 
 bool is_dusk( const time_point &p )

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -213,12 +213,16 @@ std::string display::get_moon()
 std::string display::time_approx()
 {
     const int iHour = hour_of_day<int>( calendar::turn );
-    if( iHour >= 23 || iHour <= 1 ) {
+    if( iHour >= 23 || iHour == 0 ) {
         return _( "Around midnight" );
     } else if( iHour <= 4 ) {
         return _( "Dead of night" );
-    } else if( iHour <= 6 ) {
+    } else if( is_night( calendar::turn ) ) {
+        return _( "Night" );
+    } else if( is_dawn( calendar::turn ) ) {
         return _( "Around dawn" );
+    } else if( is_dusk( calendar::turn ) ) {
+        return _( "Around dusk" );
     } else if( iHour <= 8 ) {
         return _( "Early morning" );
     } else if( iHour <= 10 ) {
@@ -229,8 +233,6 @@ std::string display::time_approx()
         return _( "Afternoon" );
     } else if( iHour <= 18 ) {
         return _( "Early evening" );
-    } else if( iHour <= 20 ) {
-        return _( "Around dusk" );
     }
     return _( "Night" );
 }

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -215,24 +215,26 @@ std::string display::time_approx()
     const int iHour = hour_of_day<int>( calendar::turn );
     if( iHour >= 23 || iHour == 0 ) {
         return _( "Around midnight" );
-    } else if( iHour <= 4 ) {
-        return _( "Dead of night" );
-    } else if( is_night( calendar::turn ) ) {
-        return _( "Night" );
     } else if( is_dawn( calendar::turn ) ) {
         return _( "Around dawn" );
     } else if( is_dusk( calendar::turn ) ) {
         return _( "Around dusk" );
-    } else if( iHour <= 8 ) {
+    } else if( iHour <= 3 && is_night( calendar::turn ) ) {
+        return _( "Dead of night" );
+    } else if( is_night( calendar::turn ) ) {
+        return _( "Night" );
+    } else if( iHour <= 7 ) {
         return _( "Early morning" );
     } else if( iHour <= 10 ) {
         return _( "Morning" );
-    } else if( iHour <= 13 ) {
+    } else if( iHour <= 12 ) {
         return _( "Around noon" );
     } else if( iHour <= 16 ) {
         return _( "Afternoon" );
     } else if( iHour <= 18 ) {
         return _( "Early evening" );
+    } else if( iHour <= 20 ) {
+        return _( "Evening" );
     }
     return _( "Night" );
 }

--- a/tests/sun_test.cpp
+++ b/tests/sun_test.cpp
@@ -17,13 +17,11 @@
 
 // The 24-hour solar cycle has four overlapping parts, as defined by four calendar.cpp functions:
 //
-// is_night : While the Sun is below the horizon
-// is_day   : While the Sun is above -12° altitude
-// is_dawn, is_dusk : While the Sun is near the horizon at the appropriate end
+// is_night : While the Sun is below -6° altitude
+// is_day   : While the Sun is above -1° altitude
+// is_dawn, is_dusk : While the Sun is in between -6° to -1° at the appropriate end
 //                    of the day
 //
-// Day and night overlap, and dawn and dusk both overlap with both day and
-// night.
 //
 // The times of sunrise and sunset will naturally depend on the current time of year; this aspect is
 // covered by the "sunrise and sunset" and solstice/equinox tests later in this file. Here we simply
@@ -56,7 +54,7 @@ TEST_CASE( "daily solar cycle", "[sun][night][dawn][day][dusk]" )
     SECTION( "Dawn" ) {
         CHECK_FALSE( is_night( today_sunrise ) );
         CHECK( is_dawn( today_sunrise - 1_seconds ) );
-        CHECK( is_dawn( today_sunrise - 30_minutes ) );
+        CHECK( is_dawn( today_sunrise - 20_minutes ) );
 
         // Dawn stops at 1 degrees
         CHECK_FALSE( is_dawn( today_sunrise + 7_minutes ) );
@@ -92,8 +90,7 @@ TEST_CASE( "daily solar cycle", "[sun][night][dawn][day][dusk]" )
     SECTION( "Dusk" ) {
         CHECK_FALSE( is_day( today_sunset + 1_seconds ) );
         CHECK( is_dusk( today_sunset + 1_seconds ) );
-        CHECK( is_dusk( today_sunset + 30_minutes ) );
-        CHECK( is_dusk( today_sunset + 1_hours - 1_seconds ) );
+        CHECK( is_dusk( today_sunset + 20_minutes ) );
     }
 
     SECTION( "Night again" ) {


### PR DESCRIPTION
#### Summary
Interface "Adjust time approximations"

#### Purpose of change

The approximate time did not match with apparent time of day.


#### Describe the solution

Use mixture of clock times and sun angles to decide what time it is.

The new definitions can overlap sometimes. The one listed first in the table will be used.

| Time | Old | New |
| ------------- | ------------- | ------------- |
| Around midnight | 23:00-01:59 | 23:00-01:00 |
| Around dawn | 06:00-06:59 | Sun between -6° and -1° (in morning)|
| Around dusk | 19:00-20:59 | Sun between -6° and -1° (in evening) |
| Dead of night | 02:00-05:59 | 01:01-03:59 and sun below -6° |
| Night |  20:59-23:00 | Sun is below -6° |
| Early morning | 07:00-08:59 | 01:00-07:59 |
| Morning | 08:00-10:59 | 08:00-10:59 |
| Around noon | 11:00-13:59 | 11:00-12:59 |
| Afternoon | 13:00-16:59 | 13:00-16:59 |
| Early evening | 17:00-18:59 | 17:00-18:59 |
| Evening | - | 19:00-20:59 |
| Night| - | Any time nothing else matches |

Earliest sunrise/latest sunset that currently can happen ingame is at around 04:00/19:30.
Latest sunrise/earliest sunset that currently can happen ingame is at around 07:00/16:00.
I think these will work decently fine for the current game location (Boston). Once modding or travel allows changing the game latitude we will need some handling for midnight sun and polar night. But those can't happen currently. 


Also adjusted `is_night()` to define night to be below -6° instead of -12° and `is_twilight()` (and by proxy the `is_dawn()` and `is_dusk()` too) to be from -6° to -1° instead of -18 to -1°`.

#### Describe alternatives you've considered

The survivor does not care about social construct like "time". If they have no clock the time approximation could be just directly based on sun angle/light levels and ignore the actual time completely.


#### Testing


#### Additional context

