### PR TITLE
Deprecate sun_intensity

### DIFF
--- a/src/calendar.cpp
+++ b/src/calendar.cpp
@@ -401,7 +401,7 @@ float sun_irradiance( const time_point &p )
 {
     const units::angle solar_alt = sun_altitude( p );
 
-    if( solar_alt < astronomical_dawn ) {
+    if( solar_alt < 0_degrees ) {
         return 0;
     }
     return max_sun_irradiance() * sin( solar_alt );

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -448,7 +448,8 @@ void Character::update_bodytemp()
                                0.0f ) );
 
     // Sunlight
-    const int sunlight_warmth = !g->is_sheltered() ? incident_sun_irradiance( get_weather().weather_id, calendar::turn ) : 0;
+    const int sunlight_warmth = !g->is_sheltered( pos() ) ? incident_sun_irradiance(
+                                    get_weather().weather_id, calendar::turn ) : 0;
     const int best_fire = get_best_fire( pos() );
 
     const int lying_warmth = use_floor_warmth ? floor_warmth( pos() ) : 0;

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -448,11 +448,7 @@ void Character::update_bodytemp()
                                0.0f ) );
 
     // Sunlight
-    const int sunlight_warmth = g->is_in_sunlight( pos() ) ?
-                                ( get_weather().weather_id->sun_intensity ==
-                                  sun_intensity_type::high ?
-                                  1000 :
-                                  500 ) : 0;
+    const int sunlight_warmth = !g->is_sheltered() ? incident_sun_irradiance( get_weather().weather_id, calendar::turn ) : 0;
     const int best_fire = get_best_fire( pos() );
 
     const int lying_warmth = use_floor_warmth ? floor_warmth( pos() ) : 0;

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -449,7 +449,7 @@ void Character::update_bodytemp()
 
     // Sunlight
     const int sunlight_warmth = !g->is_sheltered( pos() ) ? incident_sun_irradiance(
-                                    get_weather().weather_id, calendar::turn ) : 0;
+                                    get_weather().weather_id, calendar::turn ) * 1.5 : 0;
     const int best_fire = get_best_fire( pos() );
 
     const int lying_warmth = use_floor_warmth ? floor_warmth( pos() ) : 0;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4895,7 +4895,7 @@ bool game::is_empty( const tripoint_bub_ms &p )
 bool game::is_in_sunlight( const tripoint &p )
 {
     return !is_sheltered( p ) &&
-           incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > irradiance::low;
+           incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > irradiance::minimal;
 }
 
 bool game::is_sheltered( const tripoint &p )

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4898,7 +4898,7 @@ bool game::is_in_sunlight( const tripoint &p )
     bool is_inside = vp && vp->is_inside();
 
     return m.is_outside( p ) && light_level( p.z ) >= 40 && !is_night( calendar::turn ) &&
-           get_weather().weather_id->sun_intensity >= sun_intensity_type::normal &&
+           get_weather().weather_id->light_modifier >= 0.5 &&
            !is_inside;
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4894,12 +4894,7 @@ bool game::is_empty( const tripoint_bub_ms &p )
 
 bool game::is_in_sunlight( const tripoint &p )
 {
-    const optional_vpart_position vp = m.veh_at( p );
-    bool is_inside = vp && vp->is_inside();
-
-    return m.is_outside( p ) && light_level( p.z ) >= 40 && !is_night( calendar::turn ) &&
-           get_weather().weather_id->light_modifier >= 0.5 &&
-           !is_inside;
+    return !is_sheltered( p ) && incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > irradiance::low;
 }
 
 bool game::is_sheltered( const tripoint &p )

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4894,7 +4894,8 @@ bool game::is_empty( const tripoint_bub_ms &p )
 
 bool game::is_in_sunlight( const tripoint &p )
 {
-    return !is_sheltered( p ) && incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > irradiance::low;
+    return !is_sheltered( p ) &&
+           incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > irradiance::low;
 }
 
 bool game::is_sheltered( const tripoint &p )

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1244,11 +1244,12 @@ float firestarter_actor::light_mod( const tripoint &pos ) const
     if( !need_sunlight ) {
         return 1.0f;
     }
+    if( !g->is_in_sunlight( pos ) ) {
+        return 0.0f;
+    }
 
-    const float light_level = g->natural_light_level( pos.z );
-    if( get_weather().weather_id->sun_intensity >= sun_intensity_type::normal &&
-        light_level >= 60.0f && !get_map().has_flag( ter_furn_flag::TFLAG_INDOORS, pos ) ) {
-        return std::pow( light_level / 80.0f, 8 );
+    if( incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > 300 ) {
+        return std::pow( g->natural_light_level( pos.z ) / 80.0f, 8 );
     }
 
     return 0.0f;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1248,7 +1248,7 @@ float firestarter_actor::light_mod( const tripoint &pos ) const
         return 0.0f;
     }
 
-    if( incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > 300 ) {
+    if( incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > irradiance::moderate ) {
         return std::pow( g->natural_light_level( pos.z ) / 80.0f, 8 );
     }
 

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1244,7 +1244,7 @@ float firestarter_actor::light_mod( const tripoint &pos ) const
     if( !need_sunlight ) {
         return 1.0f;
     }
-    if( !g->is_in_sunlight( pos ) ) {
+    if( g->is_sheltered( pos ) ) {
         return 0.0f;
     }
 

--- a/src/medical_ui.cpp
+++ b/src/medical_ui.cpp
@@ -542,7 +542,7 @@ static medical_column draw_effects_summary( const int column_count, avatar *play
     }
 
     if( player->has_trait( trait_TROGLO ) && g->is_in_sunlight( player->pos() ) &&
-        get_weather().weather_id->sun_intensity >= sun_intensity_type::high ) {
+        incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > 500 ) {
         effects_column.add_column_line( selection_line( "In Sunlight", "The sunlight irritates you.\n",
                                         max_width ) );
     } else if( player->has_trait( trait_TROGLO2 ) && g->is_in_sunlight( player->pos() ) ) {

--- a/src/medical_ui.cpp
+++ b/src/medical_ui.cpp
@@ -542,7 +542,7 @@ static medical_column draw_effects_summary( const int column_count, avatar *play
     }
 
     if( player->has_trait( trait_TROGLO ) && g->is_in_sunlight( player->pos() ) &&
-        incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > 500 ) {
+        incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > irradiance::high ) {
         effects_column.add_column_line( selection_line( "In Sunlight", "The sunlight irritates you.\n",
                                         max_width ) );
     } else if( player->has_trait( trait_TROGLO2 ) && g->is_in_sunlight( player->pos() ) ) {

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1357,8 +1357,7 @@ void Character::disp_info( bool customize_character )
         effect_name_and_text.emplace_back( starvation_name, starvation_text );
     }
 
-    if( has_trait( trait_TROGLO ) && g->is_in_sunlight( pos() ) &&
-        get_weather().weather_id->sun_intensity >= sun_intensity_type::high ) {
+    if( has_trait( trait_TROGLO ) && g->is_in_sunlight( pos() ) && incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > 500 ) {
         effect_name_and_text.emplace_back( _( "In Sunlight" ),
                                            _( "The sunlight irritates you.\n"
                                               "Strength - 1;    Dexterity - 1;    Intelligence - 1;    Perception - 1" )

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1357,7 +1357,8 @@ void Character::disp_info( bool customize_character )
         effect_name_and_text.emplace_back( starvation_name, starvation_text );
     }
 
-    if( has_trait( trait_TROGLO ) && g->is_in_sunlight( pos() ) && incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > 500 ) {
+    if( has_trait( trait_TROGLO ) && g->is_in_sunlight( pos() ) &&
+        incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > 500 ) {
         effect_name_and_text.emplace_back( _( "In Sunlight" ),
                                            _( "The sunlight irritates you.\n"
                                               "Strength - 1;    Dexterity - 1;    Intelligence - 1;    Perception - 1" )

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1358,7 +1358,7 @@ void Character::disp_info( bool customize_character )
     }
 
     if( has_trait( trait_TROGLO ) && g->is_in_sunlight( pos() ) &&
-        incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > 500 ) {
+        incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > irradiance::high ) {
         effect_name_and_text.emplace_back( _( "In Sunlight" ),
                                            _( "The sunlight irritates you.\n"
                                               "Strength - 1;    Dexterity - 1;    Intelligence - 1;    Perception - 1" )

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -999,7 +999,7 @@ static void eff_fun_sleep( Character &u, effect &it )
         here.is_outside( u.pos() ) ) {
         if( u.has_trait( trait_CHLOROMORPH ) ) {
             // Hunger and thirst fall before your Chloromorphic physiology!
-            if( incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > 100 ) {
+            if( incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > irradiance::low ) {
                 if( u.has_active_mutation( trait_CHLOROMORPH ) && ( u.get_fatigue() <= 25 ) ) {
                     u.set_fatigue( 25 );
                 }

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -999,8 +999,7 @@ static void eff_fun_sleep( Character &u, effect &it )
         here.is_outside( u.pos() ) ) {
         if( u.has_trait( trait_CHLOROMORPH ) ) {
             // Hunger and thirst fall before your Chloromorphic physiology!
-            if( g->natural_light_level( u.posz() ) >= 12 &&
-                get_weather().weather_id->sun_intensity >= sun_intensity_type::light ) {
+            if( incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > 100 ) {
                 if( u.has_active_mutation( trait_CHLOROMORPH ) && ( u.get_fatigue() <= 25 ) ) {
                     u.set_fatigue( 25 );
                 }

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -802,7 +802,7 @@ void suffer::in_sunlight( Character &you )
 {
     const tripoint position = you.pos();
 
-    if( g->is_in_sunlight( position ) ) {
+    if( !g->is_in_sunlight( position ) ) {
         return;
     }
 

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -802,7 +802,7 @@ void suffer::in_sunlight( Character &you )
 {
     const tripoint position = you.pos();
 
-    if( g->is_sheltered( position ) || is_night( calendar::turn ) ) {
+    if( g->is_in_sunlight( position ) ) {
         return;
     }
 
@@ -815,8 +815,7 @@ void suffer::in_sunlight( Character &you )
         const bool leafiest = you.has_trait( trait_LEAVES3 );
         const double sleeve_factor = you.armwear_factor();
         const bool has_hat = you.wearing_something_on( bodypart_id( "head" ) );
-        const float weather_factor = ( get_weather().weather_id->sun_intensity >=
-                                       sun_intensity_type::normal ) ? 1.0 : 0.5; //TODO some nice curve from irradiance
+        const float weather_factor = std::max( incident_sun_irradiance( get_weather().weather_id, calendar::turn ) / irradiance::normal, 1 );
         const int player_local_temp = units::to_fahrenheit( get_weather().get_temperature( position ) );
         const int flux = ( player_local_temp - 65 ) / 2;
         if( !has_hat ) {

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -843,7 +843,7 @@ void suffer::in_sunlight( Character &you )
     }
 
     if( ( you.has_trait( trait_TROGLO ) || you.has_trait( trait_TROGLO2 ) ) &&
-        get_weather().weather_id->sun_intensity >= sun_intensity_type::high ) {
+        incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > 500 ) {
         you.mod_str_bonus( -1 );
         you.mod_dex_bonus( -1 );
         you.add_miss_reason( _( "The sunlight distracts you." ), 1 );

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -843,7 +843,7 @@ void suffer::in_sunlight( Character &you )
     }
 
     if( ( you.has_trait( trait_TROGLO ) || you.has_trait( trait_TROGLO2 ) ) &&
-        incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > 500 ) {
+        incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > irradiance::high ) {
         you.mod_str_bonus( -1 );
         you.mod_dex_bonus( -1 );
         you.add_miss_reason( _( "The sunlight distracts you." ), 1 );

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -816,7 +816,7 @@ void suffer::in_sunlight( Character &you )
         const double sleeve_factor = you.armwear_factor();
         const bool has_hat = you.wearing_something_on( bodypart_id( "head" ) );
         const float weather_factor = std::max( incident_sun_irradiance( get_weather().weather_id,
-                                               calendar::turn ) / irradiance::normal, 1 );
+                                               calendar::turn ) / irradiance::moderate, 1.f );
         const int player_local_temp = units::to_fahrenheit( get_weather().get_temperature( position ) );
         const int flux = ( player_local_temp - 65 ) / 2;
         if( !has_hat ) {

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -815,7 +815,8 @@ void suffer::in_sunlight( Character &you )
         const bool leafiest = you.has_trait( trait_LEAVES3 );
         const double sleeve_factor = you.armwear_factor();
         const bool has_hat = you.wearing_something_on( bodypart_id( "head" ) );
-        const float weather_factor = std::max( incident_sun_irradiance( get_weather().weather_id, calendar::turn ) / irradiance::normal, 1 );
+        const float weather_factor = std::max( incident_sun_irradiance( get_weather().weather_id,
+                                               calendar::turn ) / irradiance::normal, 1 );
         const int player_local_temp = units::to_fahrenheit( get_weather().get_temperature( position ) );
         const int flux = ( player_local_temp - 65 ) / 2;
         if( !has_hat ) {

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -802,7 +802,7 @@ void suffer::in_sunlight( Character &you )
 {
     const tripoint position = you.pos();
 
-    if( !g->is_in_sunlight( position ) ) {
+    if( g->is_sheltered( position ) || is_night( calendar::turn ) ) {
         return;
     }
 
@@ -816,7 +816,7 @@ void suffer::in_sunlight( Character &you )
         const double sleeve_factor = you.armwear_factor();
         const bool has_hat = you.wearing_something_on( bodypart_id( "head" ) );
         const float weather_factor = ( get_weather().weather_id->sun_intensity >=
-                                       sun_intensity_type::normal ) ? 1.0 : 0.5;
+                                       sun_intensity_type::normal ) ? 1.0 : 0.5; //TODO some nice curve from irradiance
         const int player_local_temp = units::to_fahrenheit( get_weather().get_temperature( position ) );
         const int flux = ( player_local_temp - 65 ) / 2;
         if( !has_hat ) {

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -815,7 +815,7 @@ void suffer::in_sunlight( Character &you )
         const bool leafiest = you.has_trait( trait_LEAVES3 );
         const double sleeve_factor = you.armwear_factor();
         const bool has_hat = you.wearing_something_on( bodypart_id( "head" ) );
-        const float weather_factor = std::max( incident_sun_irradiance( get_weather().weather_id,
+        const float weather_factor = std::min( incident_sun_irradiance( get_weather().weather_id,
                                                calendar::turn ) / irradiance::moderate, 1.f );
         const int player_local_temp = units::to_fahrenheit( get_weather().get_temperature( position ) );
         const int flux = ( player_local_temp - 65 ) / 2;

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -97,7 +97,7 @@ weather_type_id get_bad_weather()
 void glare( const weather_type_id &w )
 {
     Character &player_character = get_player_character();//todo npcs, also
-    //General prerequisites for glare
+    // General prerequisites for glare
     if( !is_creature_outside( player_character ) ||
         !g->is_in_sunlight( player_character.pos() ) ||
         player_character.in_sleep_state() ||
@@ -111,17 +111,19 @@ void glare( const weather_type_id &w )
     const efftype_id *effect = nullptr;
     season_type season = season_of_year( calendar::turn );
     if( season == WINTER ) {
-        //Winter snow glare: for both clear & sunny weather
+        // Winter snow glare happens at slightly cloudy weather
+		// It is enough to be "in sunlight"
         effect = &effect_snow_glare;
         dur = player_character.has_effect( *effect ) ? 1_turns : 2_turns;
-    } else if( w->sun_intensity == sun_intensity_type::high ) {
-        //Sun glare: only for bright sunny weather
+    } else if( w->light_modifier > 0.9 ) {
+        // Sun glare: only for bright sunny weather
         effect = &effect_glare;
         dur = player_character.has_effect( *effect ) ? 1_turns : 2_turns;
     }
-    //apply final glare effect
+
+    // Apply final glare effect
     if( dur > 0_turns && effect != nullptr ) {
-        //enhance/reduce by some traits
+        // Enhance/reduce by some traits
         if( player_character.has_trait( trait_CEPH_VISION ) ) {
             dur = dur * 2;
         }

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -114,7 +114,7 @@ void glare( const weather_type_id &w )
         // Winter snow glare happens at lower irradiance
         effect = &effect_snow_glare;
         dur = player_character.has_effect( *effect ) ? 1_turns : 2_turns;
-    } else if( incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > 500 ) {
+    } else if( incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > irradiance::high ) {
         effect = &effect_glare;
         dur = player_character.has_effect( *effect ) ? 1_turns : 2_turns;
     }

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -110,12 +110,11 @@ void glare( const weather_type_id &w )
     const efftype_id *effect = nullptr;
     season_type season = season_of_year( calendar::turn );
     if( season == WINTER &&
-        incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > irradiance::moderate ) {
+        incident_sun_irradiance( w, calendar::turn ) > irradiance::moderate ) {
         // Winter snow glare happens at lower irradiance
         effect = &effect_snow_glare;
         dur = player_character.has_effect( *effect ) ? 1_turns : 2_turns;
-    } else if( incident_sun_irradiance( get_weather().weather_id,
-                                        calendar::turn ) > irradiance::high ) {
+    } else if( incident_sun_irradiance( w, calendar::turn ) > irradiance::high ) {
         effect = &effect_glare;
         dur = player_character.has_effect( *effect ) ? 1_turns : 2_turns;
     }

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -110,7 +110,7 @@ void glare( const weather_type_id &w )
     const efftype_id *effect = nullptr;
     season_type season = season_of_year( calendar::turn );
     if( season == WINTER &&
-        incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > 300 ) {
+        incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > irradiance::moderate ) {
         // Winter snow glare happens at lower irradiance
         effect = &effect_snow_glare;
         dur = player_character.has_effect( *effect ) ? 1_turns : 2_turns;

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -97,9 +97,8 @@ weather_type_id get_bad_weather()
 void glare( const weather_type_id &w )
 {
     Character &player_character = get_player_character();//todo npcs, also
-    // General prerequisites for glare
-    if( !is_creature_outside( player_character ) ||
-        !g->is_in_sunlight( player_character.pos() ) ||
+    //General prerequisites for glare
+    if( g->is_sheltered( player_character.pos() ) ||
         player_character.in_sleep_state() ||
         player_character.worn_with_flag( json_flag_SUN_GLASSES ) ||
         player_character.has_flag( json_flag_GLARE_RESIST ) ||
@@ -110,20 +109,19 @@ void glare( const weather_type_id &w )
     time_duration dur = 0_turns;
     const efftype_id *effect = nullptr;
     season_type season = season_of_year( calendar::turn );
-    if( season == WINTER ) {
-        // Winter snow glare happens at slightly cloudy weather
-        // It is enough to be "in sunlight"
+    if( season == WINTER &&
+        incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > 300 ) {
+        // Winter snow glare happens at lower irradiance
         effect = &effect_snow_glare;
         dur = player_character.has_effect( *effect ) ? 1_turns : 2_turns;
-    } else if( w->light_modifier > 0.9 ) {
-        // Sun glare: only for bright sunny weather
+    } else if( incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > 500 ) {
         effect = &effect_glare;
         dur = player_character.has_effect( *effect ) ? 1_turns : 2_turns;
     }
 
-    // Apply final glare effect
+    //apply final glare effect
     if( dur > 0_turns && effect != nullptr ) {
-        // Enhance/reduce by some traits
+        //enhance/reduce by some traits
         if( player_character.has_trait( trait_CEPH_VISION ) ) {
             dur = dur * 2;
         }

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -114,7 +114,8 @@ void glare( const weather_type_id &w )
         // Winter snow glare happens at lower irradiance
         effect = &effect_snow_glare;
         dur = player_character.has_effect( *effect ) ? 1_turns : 2_turns;
-    } else if( incident_sun_irradiance( get_weather().weather_id, calendar::turn ) > irradiance::high ) {
+    } else if( incident_sun_irradiance( get_weather().weather_id,
+                                        calendar::turn ) > irradiance::high ) {
         effect = &effect_glare;
         dur = player_character.has_effect( *effect ) ? 1_turns : 2_turns;
     }

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -112,7 +112,7 @@ void glare( const weather_type_id &w )
     season_type season = season_of_year( calendar::turn );
     if( season == WINTER ) {
         // Winter snow glare happens at slightly cloudy weather
-		// It is enough to be "in sunlight"
+        // It is enough to be "in sunlight"
         effect = &effect_snow_glare;
         dur = player_character.has_effect( *effect ) ? 1_turns : 2_turns;
     } else if( w->light_modifier > 0.9 ) {

--- a/src/weather.h
+++ b/src/weather.h
@@ -47,19 +47,19 @@ static constexpr int BODYTEMP_THRESHOLD = 500;
 
 namespace irradiance
 {
-// Very rough approximation for UV index 1 at 25° sun altitude on clear day
+// Sun at 25° on a clear day. Very roughly UV index 1
 constexpr float low = 422;
 
-// Very rough approximation for UV index 3 at 35° sun anltitude on clear day
+// Sun at 35° on a clear day. Very roughly UV index 3
 constexpr float moderate = 573;
 
-// Very rough approximation for UV index 6 at 60° sun altitude on clear day
+// Sun at 60° on a clear day. Very roughly UV index 6
 constexpr float high = 866;
 
-// Very rough approximation for UV index 8 at 65° sun altitude on clear day
+// Sun at 65° on a clear day. Very roughly UV index 8
 constexpr float very_high = 906;
 
-// Very rough approximation for UV index 11 at 70° sun altitude on clear day
+// Sun at 70° on a clear day. Very roughly UV index 11
 constexpr float extreme = 940;
 }
 

--- a/src/weather.h
+++ b/src/weather.h
@@ -45,6 +45,24 @@ static constexpr int BODYTEMP_SCORCHING = 9500;
 static constexpr int BODYTEMP_THRESHOLD = 500;
 ///@}
 
+namespace irradiance
+{
+// Very rough approximation for UV index 1 at 25° sun altitude on clear day
+constexpr float low = 422;
+
+// Very rough approximation for UV index 3 at 35° sun anltitude on clear day
+constexpr float moderate = 573;
+
+// Very rough approximation for UV index 6 at 60° sun altitude on clear day
+constexpr float high = 866;
+
+// Very rough approximation for UV index 8 at 65° sun altitude on clear day
+constexpr float very_high = 906;
+
+// Very rough approximation for UV index 11 at 70° sun altitude on clear day
+constexpr float extreme = 940;
+}
+
 #include <cstdint>
 #include <iosfwd>
 #include <map>

--- a/src/weather.h
+++ b/src/weather.h
@@ -47,6 +47,9 @@ static constexpr int BODYTEMP_THRESHOLD = 500;
 
 namespace irradiance
 {
+// Sun at 5° on a clear day.
+constexpr float minimal = 87;
+
 // Sun at 25° on a clear day. Very roughly UV index 1
 constexpr float low = 422;
 


### PR DESCRIPTION

#### Summary
Infrastructure "Deprecate sun_intensity"

#### Purpose of change

`sun_intensity` defines how "bright" a weather is. It is used to measure how bright sunlight is.
It is not very good measure of sunlight brightness as it does not take sunlight into account.

#### Describe the solution

Replace `sun_intensity` with combination of `light_modifier` (weather sunlight multiplier) and sun irradiance.

Glare
* Old: During winter it is enought to be "in sunlight". Otherwise when `sun_intensity = high`
* New: During winter it is enought to be "in sunlight". Otherwise when `light_modifier > 0.9`

In sunlight
* Old: `sun_intensity >= normal`
* New: `light_modifier >= 0.5`

Photosyntesis
* Old: `light_level > 12` and `sun_intensity > light`
* New: `Sun irradiance > 100`

"TROGLO" sun irritation
* Old: `sun_intensity > high`
* New:  `Sun irradiance > 500`

Firestarter
* Old:  `sun_intensity > normal` and `light_level > 60`
* New: "in sunlight" and `Sun irradiance > 300`

#### Describe alternatives you've considered



#### Testing


#### Additional context

